### PR TITLE
feat: 播放声音

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1157,15 +1157,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1275,12 +1266,6 @@ dependencies = [
  "smallvec",
  "zune-inflate",
 ]
-
-[[package]]
-name = "extended"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
 
 [[package]]
 name = "fastrand"
@@ -1858,6 +1843,12 @@ name = "hmac-sha256"
 version = "1.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
+
+[[package]]
+name = "hound"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
 
 [[package]]
 name = "html5ever"
@@ -3985,8 +3976,8 @@ checksum = "e40ecf59e742e03336be6a3d53755e789fd05a059fa22dfa0ed624722319e183"
 dependencies = [
  "cpal",
  "dasp_sample",
+ "hound",
  "num-rational",
- "symphonia",
  "tracing",
 ]
 
@@ -4580,153 +4571,6 @@ name = "symlink"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
-
-[[package]]
-name = "symphonia"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
-dependencies = [
- "lazy_static",
- "symphonia-bundle-flac",
- "symphonia-bundle-mp3",
- "symphonia-codec-aac",
- "symphonia-codec-pcm",
- "symphonia-codec-vorbis",
- "symphonia-core",
- "symphonia-format-isomp4",
- "symphonia-format-ogg",
- "symphonia-format-riff",
- "symphonia-metadata",
-]
-
-[[package]]
-name = "symphonia-bundle-flac"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91565e180aea25d9b80a910c546802526ffd0072d0b8974e3ebe59b686c9976"
-dependencies = [
- "log",
- "symphonia-core",
- "symphonia-metadata",
- "symphonia-utils-xiph",
-]
-
-[[package]]
-name = "symphonia-bundle-mp3"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4872dd6bb56bf5eac799e3e957aa1981086c3e613b27e0ac23b176054f7c57ed"
-dependencies = [
- "lazy_static",
- "log",
- "symphonia-core",
- "symphonia-metadata",
-]
-
-[[package]]
-name = "symphonia-codec-aac"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c263845aa86881416849c1729a54c7f55164f8b96111dba59de46849e73a790"
-dependencies = [
- "lazy_static",
- "log",
- "symphonia-core",
-]
-
-[[package]]
-name = "symphonia-codec-pcm"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e89d716c01541ad3ebe7c91ce4c8d38a7cf266a3f7b2f090b108fb0cb031d95"
-dependencies = [
- "log",
- "symphonia-core",
-]
-
-[[package]]
-name = "symphonia-codec-vorbis"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f025837c309cd69ffef572750b4a2257b59552c5399a5e49707cc5b1b85d1c73"
-dependencies = [
- "log",
- "symphonia-core",
- "symphonia-utils-xiph",
-]
-
-[[package]]
-name = "symphonia-core"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea00cc4f79b7f6bb7ff87eddc065a1066f3a43fe1875979056672c9ef948c2af"
-dependencies = [
- "arrayvec",
- "bitflags 1.3.2",
- "bytemuck",
- "lazy_static",
- "log",
-]
-
-[[package]]
-name = "symphonia-format-isomp4"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243739585d11f81daf8dac8d9f3d18cc7898f6c09a259675fc364b382c30e0a5"
-dependencies = [
- "encoding_rs",
- "log",
- "symphonia-core",
- "symphonia-metadata",
- "symphonia-utils-xiph",
-]
-
-[[package]]
-name = "symphonia-format-ogg"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b4955c67c1ed3aa8ae8428d04ca8397fbef6a19b2b051e73b5da8b1435639cb"
-dependencies = [
- "log",
- "symphonia-core",
- "symphonia-metadata",
- "symphonia-utils-xiph",
-]
-
-[[package]]
-name = "symphonia-format-riff"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d7c3df0e7d94efb68401d81906eae73c02b40d5ec1a141962c592d0f11a96f"
-dependencies = [
- "extended",
- "log",
- "symphonia-core",
- "symphonia-metadata",
-]
-
-[[package]]
-name = "symphonia-metadata"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36306ff42b9ffe6e5afc99d49e121e0bd62fe79b9db7b9681d48e29fa19e6b16"
-dependencies = [
- "encoding_rs",
- "lazy_static",
- "log",
- "symphonia-core",
-]
-
-[[package]]
-name = "symphonia-utils-xiph"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27c85ab799a338446b68eec77abf42e1a6f1bb490656e121c6e27bfbab9f16"
-dependencies = [
- "symphonia-core",
- "symphonia-metadata",
-]
 
 [[package]]
 name = "syn"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -67,6 +67,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "alsa"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
+dependencies = [
+ "alsa-sys",
+ "bitflags 2.13.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "alsa-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -719,6 +741,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "coreaudio-rs"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aae284fbaf7d27aa0e292f7677dfbe26503b0d555026f702940805a630eac17"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "objc2-audio-toolbox",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "cpal"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbd307f43cc2a697e2d1f8bc7a1d824b5269e052209e28883e5bc04d095aaa3f"
+dependencies = [
+ "alsa",
+ "coreaudio-rs",
+ "dasp_sample",
+ "jni",
+ "js-sys",
+ "libc",
+ "mach2",
+ "ndk",
+ "ndk-context",
+ "num-derive",
+ "num-traits",
+ "objc2-audio-toolbox",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows 0.54.0",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -867,6 +929,12 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "dasp_sample"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "dbus"
@@ -1089,6 +1157,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1198,6 +1275,12 @@ dependencies = [
  "smallvec",
  "zune-inflate",
 ]
+
+[[package]]
+name = "extended"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
 
 [[package]]
 name = "fastrand"
@@ -2430,6 +2513,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e20f57f9918e5bd7bc58c22cdd70a6afc7375d4dd9683af5f2b34bd3d2bba619"
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2613,6 +2705,12 @@ dependencies = [
  "raw-window-handle",
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "ndk-sys"
@@ -2799,6 +2897,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-audio-toolbox"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6948501a91121d6399b79abaa33a8aa4ea7857fe019f341b8c23ad6e81b79b08"
+dependencies = [
+ "bitflags 2.13.1",
+ "libc",
+ "objc2",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-cloud-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2807,6 +2920,28 @@ dependencies = [
  "bitflags 2.13.1",
  "objc2",
  "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
+dependencies = [
+ "dispatch2",
+ "objc2",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
 ]
 
 [[package]]
@@ -2982,6 +3117,7 @@ dependencies = [
  "imageproc 0.27.0",
  "indexmap 2.14.0",
  "rapidocr-core",
+ "rodio",
  "scopeguard",
  "serde",
  "serde_json",
@@ -2991,7 +3127,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -3842,6 +3978,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 
 [[package]]
+name = "rodio"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40ecf59e742e03336be6a3d53755e789fd05a059fa22dfa0ed624722319e183"
+dependencies = [
+ "cpal",
+ "dasp_sample",
+ "num-rational",
+ "symphonia",
+ "tracing",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4433,6 +4582,153 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
+name = "symphonia"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
+dependencies = [
+ "lazy_static",
+ "symphonia-bundle-flac",
+ "symphonia-bundle-mp3",
+ "symphonia-codec-aac",
+ "symphonia-codec-pcm",
+ "symphonia-codec-vorbis",
+ "symphonia-core",
+ "symphonia-format-isomp4",
+ "symphonia-format-ogg",
+ "symphonia-format-riff",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-bundle-flac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91565e180aea25d9b80a910c546802526ffd0072d0b8974e3ebe59b686c9976"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-bundle-mp3"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4872dd6bb56bf5eac799e3e957aa1981086c3e613b27e0ac23b176054f7c57ed"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-codec-aac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c263845aa86881416849c1729a54c7f55164f8b96111dba59de46849e73a790"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-pcm"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e89d716c01541ad3ebe7c91ce4c8d38a7cf266a3f7b2f090b108fb0cb031d95"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-vorbis"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f025837c309cd69ffef572750b4a2257b59552c5399a5e49707cc5b1b85d1c73"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-core"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea00cc4f79b7f6bb7ff87eddc065a1066f3a43fe1875979056672c9ef948c2af"
+dependencies = [
+ "arrayvec",
+ "bitflags 1.3.2",
+ "bytemuck",
+ "lazy_static",
+ "log",
+]
+
+[[package]]
+name = "symphonia-format-isomp4"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "243739585d11f81daf8dac8d9f3d18cc7898f6c09a259675fc364b382c30e0a5"
+dependencies = [
+ "encoding_rs",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-ogg"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b4955c67c1ed3aa8ae8428d04ca8397fbef6a19b2b051e73b5da8b1435639cb"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-riff"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d7c3df0e7d94efb68401d81906eae73c02b40d5ec1a141962c592d0f11a96f"
+dependencies = [
+ "extended",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-metadata"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36306ff42b9ffe6e5afc99d49e121e0bd62fe79b9db7b9681d48e29fa19e6b16"
+dependencies = [
+ "encoding_rs",
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-utils-xiph"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27c85ab799a338446b68eec77abf42e1a6f1bb490656e121c6e27bfbab9f16"
+dependencies = [
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4531,7 +4827,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -4602,7 +4898,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4701,7 +4997,7 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.19",
  "url",
- "windows",
+ "windows 0.61.3",
  "zbus",
 ]
 
@@ -4727,7 +5023,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4752,7 +5048,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -5647,7 +5943,7 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
@@ -5671,7 +5967,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.19",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -5749,6 +6045,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+dependencies = [
+ "windows-core 0.54.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -5767,6 +6073,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+dependencies = [
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5848,6 +6164,15 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6139,7 +6464,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,6 +29,7 @@ image = "0.25.10"
 imageproc = "0.27.0"
 indexmap = { version = "2.14.0", features = ["serde"] }
 rapidocr-core = { version = "0.2.2", default-features = false }
+rodio = { version = "0.21.1", features = ["tracing"] }
 scopeguard = "1.2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,7 +29,7 @@ image = "0.25.10"
 imageproc = "0.27.0"
 indexmap = { version = "2.14.0", features = ["serde"] }
 rapidocr-core = { version = "0.2.2", default-features = false }
-rodio = { version = "0.21.1", features = ["tracing"] }
+rodio = { version = "0.21.1", features = ["hound", "playback", "tracing"], default-features = false }
 scopeguard = "1.2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -5,13 +5,31 @@ use serde::{Deserialize, Serialize};
 use tracing::warn;
 
 /// 应用配置。
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct OeaConfig {
     /// 配置文件版本号（用于升级时迁移配置）
     pub version: (u32, u32),
     /// 关闭时最小化到托盘而不是退出应用
     pub minimize_to_tray: bool,
+    /// 扫描音效音量（0.0–1.0）
+    #[serde(default = "default_sound_volume")]
+    pub sound_volume: f32,
+}
+
+/// `sound_volume` 字段默认值。
+fn default_sound_volume() -> f32 {
+    0.8
+}
+
+impl Default for OeaConfig {
+    fn default() -> Self {
+        Self {
+            version: (0, 0),
+            minimize_to_tray: false,
+            sound_volume: 0.8,
+        }
+    }
 }
 
 /// 从配置文件加载；文件不存在或解析失败时回退默认配置。

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -18,8 +18,8 @@ pub struct OeaConfig {
 }
 
 /// `sound_volume` 字段默认值。
-fn default_sound_volume() -> f32 {
-    0.8
+const fn default_sound_volume() -> f32 {
+    0.5
 }
 
 impl Default for OeaConfig {
@@ -27,7 +27,7 @@ impl Default for OeaConfig {
         Self {
             version: (0, 0),
             minimize_to_tray: false,
-            sound_volume: 0.8,
+            sound_volume: default_sound_volume(),
         }
     }
 }

--- a/src-tauri/src/controller.rs
+++ b/src-tauri/src/controller.rs
@@ -20,12 +20,13 @@ use crate::{
     app_paths::AppPaths,
     config::OeaConfig,
     connect::connect_to_game,
+    data::AppData,
     hotkey::KeyEvent,
     logger::LogEntry,
     ocr::OcrEngine,
     scene::SceneManager,
     task::{TaskStopped, run_task},
-    tasks::archive_scan::{ArchiveScanTask, CorrectionIndex, ScanReporter, ScanResult},
+    tasks::archive_scan::{ArchiveScanTask, ScanReporter, ScanResult},
     types::{ArchiveAcquisitionContract, PrtsData},
     window::{self, ForegroundGuard},
 };
@@ -72,12 +73,8 @@ pub struct Controller {
     foreground: ForegroundGuard,
     /// Tauri 应用句柄（向前端 emit 事件）
     handle: AppHandle,
-    /// prts.json 完整数据（供前端查询分类中文名 / 自动补全候选）
-    prts: Arc<PrtsData>,
-    /// 档案获取契约（archive_acquisition_contract.json，供前端按档案 id 查询获取方式）
-    archive_acquisition_contract: Arc<ArchiveAcquisitionContract>,
-    /// 档案标题纠错索引（应用启动时从 prts.json 构建一次）
-    correction: Arc<CorrectionIndex>,
+    /// 静态数据（prts.json / 档案获取契约 / 纠错索引，启动时统一加载）
+    app_data: AppData,
     /// 日志写入线程守卫（保活）
     _logger_guard: tracing_appender::non_blocking::WorkerGuard,
 }
@@ -96,9 +93,7 @@ impl Controller {
         scan_index: Arc<AtomicU32>,
         foreground: ForegroundGuard,
         handle: AppHandle,
-        prts: Arc<PrtsData>,
-        archive_acquisition_contract: Arc<ArchiveAcquisitionContract>,
-        correction: Arc<CorrectionIndex>,
+        app_data: AppData,
         _logger_guard: tracing_appender::non_blocking::WorkerGuard,
     ) -> Self {
         Self {
@@ -112,9 +107,7 @@ impl Controller {
             scan_index,
             foreground,
             handle,
-            prts,
-            archive_acquisition_contract,
-            correction,
+            app_data,
             _logger_guard,
         }
     }
@@ -144,12 +137,12 @@ impl Controller {
 
     /// 返回 prts.json 完整数据（供前端查询分类中文名 / 自动补全候选）。
     pub fn prts_data(&self) -> Arc<PrtsData> {
-        Arc::clone(&self.prts)
+        self.app_data.prts()
     }
 
     /// 返回档案获取契约完整数据（供前端按档案 id 查询获取方式）。
     pub fn archive_acquisition_contract_data(&self) -> Arc<ArchiveAcquisitionContract> {
-        Arc::clone(&self.archive_acquisition_contract)
+        self.app_data.archive_acquisition_contract()
     }
 
     // ========== 启动 / 停止 / 退出 ==========
@@ -194,7 +187,7 @@ impl Controller {
                 session.reset_stop();
 
                 // 执行扫描档案库任务（阻塞，期间任务内部轮询停止标志）
-                let task = ArchiveScanTask::new(this.reporter(), Arc::clone(&this.correction));
+                let task = ArchiveScanTask::new(this.reporter(), this.app_data.correction());
                 let result = run_task(&task, &mut session, &this.scenes);
 
                 // 区分"被停止"与"出错"

--- a/src-tauri/src/controller.rs
+++ b/src-tauri/src/controller.rs
@@ -25,6 +25,7 @@ use crate::{
     logger::LogEntry,
     ocr::OcrEngine,
     scene::SceneManager,
+    sound,
     task::{TaskStopped, run_task},
     tasks::archive_scan::{ArchiveScanTask, ScanReporter, ScanResult},
     types::{ArchiveAcquisitionContract, PrtsData},
@@ -135,6 +136,18 @@ impl Controller {
         )
     }
 
+    /// 播放扫描提示音（音量取配置；开始/自然完成播 enable，失败/被停止播 disable）。
+    fn play_scan_sound(&self, enable: bool) {
+        let volume = self
+            .oea_config()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .sound_volume;
+        let name = if enable { "enable.wav" } else { "disable.wav" };
+        let path = self.app_path.resources_dir().join("sounds").join(name);
+        sound::play_wav(&path, volume);
+    }
+
     /// 返回 prts.json 完整数据（供前端查询分类中文名 / 自动补全候选）。
     pub fn prts_data(&self) -> Arc<PrtsData> {
         self.app_data.prts()
@@ -159,6 +172,7 @@ impl Controller {
         }
         info!("收到启动扫描档案库任务请求");
         self.emit_status();
+        self.play_scan_sound(true);
 
         let this = Arc::clone(self);
         thread::Builder::new()
@@ -173,6 +187,7 @@ impl Controller {
                     Ok(s) => s,
                     Err(e) => {
                         error!("连接游戏失败: {e:#}");
+                        this.play_scan_sound(false);
                         this.finish_scan();
                         return;
                     }
@@ -192,11 +207,18 @@ impl Controller {
 
                 // 区分"被停止"与"出错"
                 match result {
-                    Ok(_) => info!("========== 扫描档案库任务执行完毕 =========="),
+                    Ok(_) => {
+                        info!("========== 扫描档案库任务执行完毕 ==========");
+                        this.play_scan_sound(true);
+                    }
                     Err(e) if e.downcast_ref::<TaskStopped>().is_some() => {
                         info!("扫描档案库任务已被用户停止");
+                        this.play_scan_sound(false);
                     }
-                    Err(e) => error!("扫描档案库任务执行失败: {e:#}"),
+                    Err(e) => {
+                        error!("扫描档案库任务执行失败: {e:#}");
+                        this.play_scan_sound(false);
+                    }
                 }
 
                 this.finish_scan();

--- a/src-tauri/src/controller.rs
+++ b/src-tauri/src/controller.rs
@@ -172,7 +172,6 @@ impl Controller {
         }
         info!("收到启动扫描档案库任务请求");
         self.emit_status();
-        self.play_scan_sound(true);
 
         let this = Arc::clone(self);
         thread::Builder::new()
@@ -200,6 +199,10 @@ impl Controller {
 
                 // 清除上一次可能残留的停止信号
                 session.reset_stop();
+
+                // 启动检查通过、任务真正开始执行前播放 enable 提示音
+                // （避免"启动后立即失败"时 enable/disable 两个音效同时播放）
+                this.play_scan_sound(true);
 
                 // 执行扫描档案库任务（阻塞，期间任务内部轮询停止标志）
                 let task = ArchiveScanTask::new(this.reporter(), this.app_data.correction());

--- a/src-tauri/src/data/mod.rs
+++ b/src-tauri/src/data/mod.rs
@@ -1,0 +1,78 @@
+//! 静态数据文件统一管理。
+//!
+//! 集中加载 `resources/data/` 下的运行时数据文件（如 `prts.json`、
+//! `archive_acquisition_contract.json`），统一读取、解析、日志与错误处理。
+//!
+//! 应用启动时调用 [`AppData::load`] 一次，之后各模块只读共享（E1 严格策略：
+//! 任一数据文件缺失或损坏即视为致命错误，启动失败并指明是哪个文件）。
+
+use std::fs;
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use serde::de::DeserializeOwned;
+use tracing::info;
+
+use crate::{
+    app_paths::AppPaths,
+    tasks::archive_scan::CorrectionIndex,
+    types::{ArchiveAcquisitionContract, PrtsData},
+};
+
+/// 运行时加载的静态数据（不可变，跨线程只读共享）。
+pub struct AppData {
+    /// prts.json 完整数据（供前端查询分类中文名 / 自动补全候选，并派生纠错索引）
+    prts: Arc<PrtsData>,
+    /// 档案获取契约（archive_acquisition_contract.json，供前端按档案 id 查询获取方式）
+    archive_acquisition_contract: Arc<ArchiveAcquisitionContract>,
+    /// 档案标题纠错索引（启动时从 prts.json 派生构建一次）
+    correction: Arc<CorrectionIndex>,
+}
+
+impl AppData {
+    /// 从 `resources/data/` 加载全部静态数据文件（新增数据文件在此登记）。
+    pub fn load(app_paths: &AppPaths) -> Result<Self> {
+        let data_dir = app_paths.resources_dir().join("data");
+
+        let prts = Arc::new(Self::load_json::<PrtsData>(&data_dir.join("prts.json"))?);
+        let correction = Arc::new(CorrectionIndex::from_prts(&prts));
+        info!("已加载 prts.json（{} 个档案条目）", correction.len());
+
+        let archive_acquisition_contract = Arc::new(Self::load_json::<ArchiveAcquisitionContract>(
+            &data_dir.join("archive_acquisition_contract.json"),
+        )?);
+        info!(
+            "已加载 archive_acquisition_contract.json（{} 条获取契约）",
+            archive_acquisition_contract.len()
+        );
+
+        Ok(Self {
+            prts,
+            archive_acquisition_contract,
+            correction,
+        })
+    }
+
+    /// prts.json 完整数据。
+    pub fn prts(&self) -> Arc<PrtsData> {
+        Arc::clone(&self.prts)
+    }
+
+    /// 档案获取契约完整数据。
+    pub fn archive_acquisition_contract(&self) -> Arc<ArchiveAcquisitionContract> {
+        Arc::clone(&self.archive_acquisition_contract)
+    }
+
+    /// 档案标题纠错索引。
+    pub fn correction(&self) -> Arc<CorrectionIndex> {
+        Arc::clone(&self.correction)
+    }
+
+    /// 读取并解析一个 JSON 数据文件；失败时错误信息带完整文件路径。
+    fn load_json<T: DeserializeOwned>(path: &Path) -> Result<T> {
+        let text = fs::read_to_string(path)
+            .with_context(|| format!("读取数据文件 {} 失败", path.display()))?;
+        serde_json::from_str(&text).with_context(|| format!("解析数据文件 {} 失败", path.display()))
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ pub mod app_paths;
 pub mod config;
 pub mod connect;
 pub mod controller;
+pub mod data;
 pub mod hotkey;
 mod include;
 pub mod input;
@@ -26,20 +27,15 @@ use std::fs;
 use std::sync::atomic::{AtomicBool, AtomicU32};
 use std::sync::{Arc, Mutex, mpsc};
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Result, anyhow};
 use rapidocr_core::config::PipelineConfig;
 use tauri::Manager;
 use tracing::info;
 use windows::Win32::Foundation::HWND;
 
 use crate::{
-    app_paths::AppPaths,
-    controller::Controller,
-    ocr::OcrEngine,
-    scene::create_scene_manager,
-    tasks::archive_scan::CorrectionIndex,
-    types::{ArchiveAcquisitionContract, PrtsData},
-    window::ForegroundGuard,
+    app_paths::AppPaths, controller::Controller, data::AppData, ocr::OcrEngine,
+    scene::create_scene_manager, window::ForegroundGuard,
 };
 
 /// 获取 OEA 主窗口的原生窗口句柄（用于前台窗口判定）。
@@ -130,29 +126,9 @@ pub fn run() {
             let ocr_engine = OcrEngine::new(pipeline_config, &app_paths.models_dir())?;
             let ocr = Arc::new(Mutex::new(ocr_engine));
 
-            // 加载 prts.json：一次读取，同时用于纠错索引（后端）与前端数据查询
-            let prts_path = app_paths.resources_dir().join("data/prts.json");
-            let prts_text = fs::read_to_string(&prts_path).context("读取 prts.json 失败")?;
-            let prts = Arc::new(
-                serde_json::from_str::<PrtsData>(&prts_text).context("解析 prts.json 失败")?,
-            );
-            let correction = Arc::new(CorrectionIndex::from_prts(&prts));
-            info!("已加载 prts.json（{} 个档案条目）", correction.len());
-
-            // 加载档案获取契约：供前端按档案 id 展示获取方式
-            let contract_path = app_paths
-                .resources_dir()
-                .join("data/archive_acquisition_contract.json");
-            let contract_text = fs::read_to_string(&contract_path)
-                .context("读取 archive_acquisition_contract.json 失败")?;
-            let archive_acquisition_contract = Arc::new(
-                serde_json::from_str::<ArchiveAcquisitionContract>(&contract_text)
-                    .context("解析 archive_acquisition_contract.json 失败")?,
-            );
-            info!(
-                "已加载 archive_acquisition_contract.json（{} 条获取契约）",
-                archive_acquisition_contract.len()
-            );
+            // 加载静态数据文件（prts.json / archive_acquisition_contract.json / 纠错索引），
+            // 缺失或损坏视为致命错误（E1 严格策略）
+            let app_data = AppData::load(&app_paths)?;
 
             // 场景管理器（本游戏全部场景，注册顺序即识别优先级）
             let scenes = Arc::new(create_scene_manager());
@@ -178,9 +154,7 @@ pub fn run() {
                 scan_index,
                 foreground,
                 app.handle().clone(),
-                prts,
-                archive_acquisition_contract,
-                correction,
+                app_data,
                 logger_guard,
             ));
             Controller::spawn_log_loop(log_rx, app.handle().clone());

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ pub mod resolution;
 pub mod scene;
 pub mod screencap;
 pub mod session;
+pub mod sound;
 pub mod task;
 pub mod tasks;
 pub mod tauri_commands;

--- a/src-tauri/src/sound.rs
+++ b/src-tauri/src/sound.rs
@@ -1,0 +1,35 @@
+//! 音效播放（rodio 实现，支持音量调节）。
+//!
+//! 全局持有一个默认输出流（保活到应用退出；输出流被 drop 播放即停），
+//! 每次播放将解码后的音源直接混入输出流：`Mixer::add` 即播即忘、播完自动释放。
+//! 音量通过 `amplify` 逐样本增益实现，由 [`crate::config::OeaConfig::sound_volume`] 配置。
+
+use std::{fs::File, io::BufReader, path::Path, sync::OnceLock};
+
+use rodio::{Decoder, OutputStream, OutputStreamBuilder, source::Source};
+use tracing::{debug, warn};
+
+/// 全局默认输出流（首次播放时懒初始化，保活到进程退出）。
+static OUTPUT_STREAM: OnceLock<Option<OutputStream>> = OnceLock::new();
+
+/// 播放 wav 音效文件（异步，立即返回；`volume` 取值 0.0–1.0）。
+pub fn play_wav(path: &Path, volume: f32) {
+    let stream = OUTPUT_STREAM
+        .get_or_init(|| OutputStreamBuilder::open_default_stream().ok())
+        .as_ref();
+    let Some(stream) = stream else {
+        warn!("打开默认音频输出设备失败，跳过音效: {}", path.display());
+        return;
+    };
+    let Ok(file) = File::open(path) else {
+        warn!("音效文件不存在: {}", path.display());
+        return;
+    };
+    match Decoder::try_from(BufReader::new(file)) {
+        Ok(source) => {
+            stream.mixer().add(source.amplify(volume.clamp(0.0, 1.0)));
+            debug!("播放音效: {}", path.display());
+        }
+        Err(e) => warn!("解码音效失败 ({}): {e}", path.display()),
+    }
+}

--- a/src/pages/settings.vue
+++ b/src/pages/settings.vue
@@ -1,5 +1,25 @@
 <script setup lang="ts">
 import { oeaConfig, saving } from '@/utils/app/config';
+import { computed } from 'vue';
+
+/**
+ * 音量（本地数字中转）。
+ *
+ * Nuxt UI 的 USlider 内部把 v-model 当数组处理，拖动时可能先回写 `[v]`（数组）再回写 `v`（数字），
+ * 直接绑到 oeaConfig.soundVolume 会让数组短暂进入配置，触发 save_oea_config 反序列化失败
+ * （"invalid type: sequence, expected f32"）。这里只允许 number 写入配置，数组一律忽略。
+ */
+const soundVolume = computed<number>({
+  get() {
+    const value = oeaConfig.value.soundVolume;
+    return typeof value === 'number' ? value : 0.8;
+  },
+  set(value: number) {
+    if (typeof value === 'number') {
+      oeaConfig.value.soundVolume = value;
+    }
+  },
+});
 </script>
 
 <template>
@@ -33,15 +53,9 @@ import { oeaConfig, saving } from '@/utils/app/config';
               </div>
             </div>
             <div class="flex w-52 items-center gap-3">
-              <USlider
-                v-model="oeaConfig.soundVolume"
-                class="flex-1"
-                :max="1"
-                :min="0"
-                :step="0.05"
-              />
+              <USlider v-model="soundVolume" class="flex-1" :max="1" :min="0" :step="0.05" />
               <span class="w-10 text-end text-sm tabular-nums">
-                {{ Math.round(oeaConfig.soundVolume * 100) }}%
+                {{ Math.round(soundVolume * 100) }}%
               </span>
             </div>
           </div>

--- a/src/pages/settings.vue
+++ b/src/pages/settings.vue
@@ -11,10 +11,10 @@ import { computed } from 'vue';
  */
 const soundVolume = computed<number>({
   get() {
-    const value = oeaConfig.value.soundVolume;
-    return typeof value === 'number' ? value : 0.8;
+    return oeaConfig.value.soundVolume;
   },
   set(value: number) {
+    // 只在 value 是数字时写入配置，数组一律忽略
     if (typeof value === 'number') {
       oeaConfig.value.soundVolume = value;
     }

--- a/src/pages/settings.vue
+++ b/src/pages/settings.vue
@@ -20,6 +20,32 @@ import { oeaConfig, saving } from '@/utils/app/config';
             <USwitch v-model="oeaConfig.minimizeToTray" :loading="saving" />
           </div>
         </UCard>
+
+        <UCard description="扫描开始、完成与失败提示音" title="扫描音效">
+          <div class="flex items-center justify-between gap-4">
+            <div class="flex items-center gap-3">
+              <span class="i-lucide-volume-2 text-2xl text-primary" />
+              <div>
+                <p class="font-medium">扫描提示音音量</p>
+                <p class="text-sm text-toned">
+                  扫描开始与自然完成时播放提示音，失败或被停止时播放另一提示音
+                </p>
+              </div>
+            </div>
+            <div class="flex w-52 items-center gap-3">
+              <USlider
+                v-model="oeaConfig.soundVolume"
+                class="flex-1"
+                :max="1"
+                :min="0"
+                :step="0.05"
+              />
+              <span class="w-10 text-end text-sm tabular-nums">
+                {{ Math.round(oeaConfig.soundVolume * 100) }}%
+              </span>
+            </div>
+          </div>
+        </UCard>
       </UPageBody>
     </UPage>
   </UContainer>

--- a/src/types/oeaConfig.ts
+++ b/src/types/oeaConfig.ts
@@ -3,4 +3,6 @@ export interface OeaConfig {
   version: [number, number];
   /** 关闭时最小化到托盘而不是退出应用 */
   minimizeToTray: boolean;
+  /** 扫描音效音量（0.0–1.0） */
+  soundVolume: number;
 }

--- a/src/utils/app/config.ts
+++ b/src/utils/app/config.ts
@@ -7,7 +7,7 @@ export const VERSION: [number, number] = [0, 0];
 export const DEFAULT_OEA_CONFIG: OeaConfig = {
   version: VERSION,
   minimizeToTray: false,
-  soundVolume: 0.8,
+  soundVolume: 0.5,
 };
 
 export const oeaConfig = ref<OeaConfig>(DEFAULT_OEA_CONFIG);

--- a/src/utils/app/config.ts
+++ b/src/utils/app/config.ts
@@ -7,6 +7,7 @@ export const VERSION: [number, number] = [0, 0];
 export const DEFAULT_OEA_CONFIG: OeaConfig = {
   version: VERSION,
   minimizeToTray: false,
+  soundVolume: 0.8,
 };
 
 export const oeaConfig = ref<OeaConfig>(DEFAULT_OEA_CONFIG);


### PR DESCRIPTION
- **refactor(data): 抽取静态数据加载到独立 data 模块**
- **feat: 扫描提示音（rodio 后端播放，设置页音量调节）**
- **fix(sound): 精简 rodio features 仅保留 wav 解码；enable 音效推迟到启动检查通过后**
- **fix(设置): 音量滑杆经本地 number 中转，避免 USlider 数组写入配置导致保存失败**
- **feat: 默认的提示音音量改为 0.5**

## Summary by Sourcery

Introduce configurable scan sound effects, centralize static data loading into a shared AppData module, and extend configuration to support scan sound volume with a safer settings binding.

New Features:
- Add configurable scan sound effects played on scan start, completion, failure, and user stop events.
- Introduce a global sound playback module using rodio with volume control driven by configuration.
- Centralize loading of runtime static data files into a dedicated AppData module shared across the app.

Bug Fixes:
- Prevent invalid array values from being written into the soundVolume config by introducing a numeric proxy in settings.
- Delay playing the scan enable sound until after startup checks pass to avoid overlapping enable/disable sounds.

Enhancements:
- Extend application configuration to include a sound volume field with a new default of 0.5 and update frontend typings and defaults accordingly.

Build:
- Add rodio as a dependency with minimal features enabled for WAV playback.