### PR TITLE
ci: add mirrorchyan uploading

### DIFF
--- a/.github/workflows/mirrorchyan_release.yml
+++ b/.github/workflows/mirrorchyan_release.yml
@@ -1,0 +1,35 @@
+name: mirrorchyan_release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        default: ''
+        required: false
+
+jobs:
+  mirrorchyan:
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: win
+            arch: x86_64
+            filename: 'OEA-windows-x86_64-*'
+
+    steps:
+      - uses: MirrorChyan/uploading-action@v1
+        with:
+          filetype: latest-release
+          filename: ${{ matrix.filename }}
+          mirrorchyan_rid: OEA
+          tag: ${{ inputs.tag }}
+
+          os: ${{ matrix.os }}
+          arch: ${{ matrix.arch }}
+
+          owner: Logical-Byte
+          repo: open-endfield-assistant
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          upload_token: ${{ secrets.MirrorChyanUploadToken }}

--- a/.github/workflows/mirrorchyan_release_note.yml
+++ b/.github/workflows/mirrorchyan_release_note.yml
@@ -1,0 +1,26 @@
+name: mirrorchyan_release_note
+
+on:
+  workflow_dispatch:
+    inputs:
+        tag:
+            default: ''
+            required: false
+  release:
+    types: [edited]
+
+jobs:
+  mirrorchyan:
+    runs-on: macos-latest
+
+    steps:
+      - id: uploading
+        uses: MirrorChyan/release-note-action@v1
+        with:
+          mirrorchyan_rid: OEA
+          version_name: ${{ inputs.tag }}
+
+          owner: Logical-Byte
+          repo: open-endfield-assistant
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          upload_token: ${{ secrets.MirrorChyanUploadToken }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,3 +80,11 @@ jobs:
           files: releases/*.zip
           fail_on_unmatched_files: true
           generate_release_notes: true
+
+      - name: Trigger MirrorChyanUploading
+        shell: bash
+        run: |
+          gh workflow run --repo $GITHUB_REPOSITORY mirrorchyan_release.yml -f tag=${{ github.ref_name }}
+          gh workflow run --repo $GITHUB_REPOSITORY mirrorchyan_release_note.yml -f tag=${{ github.ref_name }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
接入 Mirror酱(MirrorChyan) 第三方分发服务。

- rid: `OEA`
- 上传资产: `OEA-windows-x86_64-*`
- 在 release.yml 发版后自动触发上传与 release note
- 验证通过后会补上 owner check

## Summary by Sourcery

Integrate MirrorChyan as a third-party release distribution step triggered from the existing release workflow.

CI:
- Add a post-release step in release.yml to trigger MirrorChyan upload and release-note workflows using the current tag.
- Introduce mirrorchyan_release.yml workflow to upload Windows x86_64 release artifacts to MirrorChyan using the configured repository and tokens.
- Introduce mirrorchyan_release_note.yml workflow to sync release notes to MirrorChyan on manual dispatch or edited releases.