### PR TITLE
docs: 添加 nuxt-ui-expert 技能，更改 `AGENTS.md`

### DIFF
--- a/.agents/skills/nuxt-ui-expert/SKILL.md
+++ b/.agents/skills/nuxt-ui-expert/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: nuxt-ui-expert
+description: |
+  当编写用户界面时，必须使用此技能。优先使用 Nuxt UI 提供的组件、语义化颜色和 Lucide 图标。
+---
+
+# Nuxt UI Expert
+
+### 不与 Nuxt 一起使用
+
+本项目使用 Vue 作为前端框架，使用 Nuxt UI 作为组件库。请不要将 Nuxt UI 与 Nuxt 混为一谈，本项目不使用 Nuxt 框架。
+
+### 参阅官方文档
+
+如有需要，请阅读 [llms.txt](https://ui.nuxt.com/llms.txt)。
+
+### 组件优先级
+
+优先使用 Nuxt UI 提供的组件（如 `UButton`, `UInput`, `UInputNumber`, `UBadge`, `UFileUpload` 等），而不是原生 HTML 元素。
+
+### 图标优先级
+
+优先使用 Lucide 图标（`i-lucide-*`）。
+
+### 样式优先级
+
+优先使用 Nuxt UI 组件的 props（如 `variant="subtle"`）来控制样式，而不是直接使用 Tailwind CSS 类。
+
+### 颜色类优先级
+
+优先使用 Nuxt UI 提供的语义化颜色（如 `text-toned` `text-primary` `bg-muted` `bg-accented`），尽量避免使用 Tailwind 颜色表中的颜色类（如 `text-gray-800 dark:text-gray-200` `bg-slate-100 dark:bg-slate-800`）。
+
+优先使用 Nuxt UI 提供的语义化颜色来统一深浅色主题，避免为深浅色主题分别写不同的颜色类（如 `text-gray-800 dark:text-gray-200`）。
+
+但是，如果确实需要固定的颜色，或者 Nuxt UI 提供的语义化颜色不满足需求，经慎重考虑后可以使用 Tailwind 的颜色类，也可以写自定义的颜色。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,23 +2,25 @@
 
 ### 依赖管理
 
-- 使用 `pnpm add`、`pnpm remove`、`cargo add` 或 `cargo remove` 添加或移除依赖，拒绝手动更改 `package.json` 或 `Cargo.toml` 依赖项
+- 使用 `pnpm add`、`pnpm remove`、`cargo add` 或 `cargo remove` 添加或移除依赖，拒绝手动更改 `package.json` 或 `Cargo.toml` 依赖项。
 - 除非必要，不要在命令中指定依赖版本。
 
 ### 前端
 
-- Linter 使用 `pnpm lint:fix`（修复属性排序错误）和 `pnpm fix`（任意修改后都需要运行）。
-- 拒绝写 `anotherFunction(args)` 的简单包装函数。
+- 修改代码后，运行 `pnpm fix`。
+- 拒绝写 `function foo(args) { return bar(args); }` 的简单包装函数。
+- 定义有名字的函数时使用 `function` 关键字；定义匿名函数时使用箭头函数。
+- 为所有的函数参数和返回值添加类型注解，返回 `void` 的函数除外。
 
 ### 后端
 
-- 在 `src-tauri` 目录中运行 cargo 命令，或使用 `--manifest-path src-tauri/Cargo.toml`。
+- 使用 `--manifest-path src-tauri/Cargo.toml` 运行 cargo 命令。
 - Linter 使用 `cargo check`、`cargo fix --allow-dirty` 和 `cargo clippy --fix --allow-dirty`.
 - 使用 `Arc::clone(&foo)` 克隆原子引用计数指针，拒绝 `foo.clone()`。
 - 在注释中使用反引号 backquote 包裹代码片段。
 - `unsafe` 仅包裹单个函数调用表达式。`? ; =` 放在 unsafe 块外。例：`let foo = unsafe { bar(baz) }?;`。
-- 后端的运行时行为不得更改“根目录”以外的磁盘文件。“根目录”在开发环境下，指 `package.json` 所在目录。在打包后，指可执行文件所在目录。
+- 后端的运行时行为不得更改 “根目录” 以外的磁盘文件。“根目录” 在开发环境下，指 `package.json` 所在目录。在打包后，指可执行文件所在目录。
 
-## 本地/个人偏好
+## 本地 / 个人偏好
 
 `AGENTS.local.md` 是被 Git 忽略的个人偏好文档，在开始工作前读取。如有冲突，以本文件 `AGENTS.md` 为准。


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

记录 Nuxt UI 使用约定，并收紧前端和后端的智能体（agent）编码规范。

文档：
- 更新 `AGENTS.md`，加入更严格的前端类型约束、lint 规则和函数风格规范，细化后端 Cargo 使用措辞，并进行少量格式调整。
- 新增 `nuxt-ui-expert` 技能文档，描述在 UI 中优先使用 Nuxt UI 组件、Lucide 图标、语义化颜色以及样式优先级的推荐做法。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document Nuxt UI usage conventions and tighten agent coding guidelines for frontend and backend.

Documentation:
- Update AGENTS.md with stricter frontend typing, linting, and function-style guidelines, refined backend cargo usage wording, and minor formatting tweaks.
- Add nuxt-ui-expert skill documentation describing preferred use of Nuxt UI components, Lucide icons, semantic colors, and styling priorities for the UI.

</details>