### PR TITLE
[Refactor] 使用 WindowHandle 封装 HWND

### DIFF
--- a/src-tauri/src/connect.rs
+++ b/src-tauri/src/connect.rs
@@ -11,12 +11,10 @@ use anyhow::{Context, Result, bail};
 use tracing::{info, warn};
 
 use crate::{
-    input::SeizeInput,
     ocr::OcrEngine,
     resolution::GameResolution,
-    screencap::PrintWindowScreencap,
     session::{Session, StopToken},
-    window::{self, hdr},
+    windows_ops,
 };
 
 /// 连接游戏窗口并组装会话。
@@ -33,23 +31,24 @@ pub fn connect_to_game(
     stop: StopToken,
 ) -> Result<Session> {
     // 1. 获取游戏窗口（仅确保窗口在屏幕上，不抢占前台）
-    let hwnd = window::get_window_by_title(
-        Some(window::ENDFIELD_WINDOW_CLASS),
-        Some(window::ENDFIELD_WINDOW_TITLE),
+    let hwnd = windows_ops::window::get_window_by_title(
+        Some(windows_ops::window::ENDFIELD_WINDOW_CLASS),
+        Some(windows_ops::window::ENDFIELD_WINDOW_TITLE),
     )
     .context("未找到终末地窗口，请先打开游戏")?;
     // 若窗口被最小化则先恢复，否则 `ensure_window_on_screen` 会跳过调整
-    let _ = window::restore_window_if_minimized(hwnd).inspect_err(|e| warn!("恢复窗口失败: {e:#}"));
-    let _ =
-        window::ensure_window_on_screen(hwnd).inspect_err(|e| warn!("确保窗口在屏幕上失败: {e:#}"));
+    let _ = windows_ops::window::restore_window_if_minimized(hwnd)
+        .inspect_err(|e| warn!("恢复窗口失败: {e:#}"));
+    let _ = windows_ops::window::ensure_window_on_screen(hwnd)
+        .inspect_err(|e| warn!("确保窗口在屏幕上失败: {e:#}"));
 
     // 2. 检测分辨率
-    let client_rect = window::get_client_rect(hwnd)?;
+    let client_rect = windows_ops::window::get_client_rect(hwnd)?;
     let resolution = GameResolution::new(client_rect.width() as u32, client_rect.height() as u32)?;
     info!("游戏分辨率: {}×{}", resolution.width, resolution.height);
 
     // 3. 检查终末地所在显示器是否开启 HDR（开启会致截图颜色失真、影响识别，拒绝执行）
-    match hdr::is_hdr_enabled_on_window_monitor(hwnd) {
+    match windows_ops::window::hdr::is_hdr_enabled_on_window_monitor(hwnd) {
         Ok(true) => {
             bail!("终末地所在显示器已开启 HDR，截图颜色会失真导致识别异常，请关闭 HDR 后重试")
         }
@@ -58,8 +57,8 @@ pub fn connect_to_game(
     }
 
     // 4. 创建截图器与输入器
-    let screencap = Box::new(PrintWindowScreencap::new(hwnd));
-    let input = Box::new(SeizeInput::new(hwnd, false));
+    let screencap = Box::new(windows_ops::capture::PrintWindowScreencap::new(hwnd));
+    let input = Box::new(windows_ops::input::SeizeInput::new(hwnd, false));
 
     // 5. 组装 Session（复用共享 OCR 引擎与模板目录）
     Ok(Session::new(

--- a/src-tauri/src/controller.rs
+++ b/src-tauri/src/controller.rs
@@ -29,7 +29,7 @@ use crate::{
     task::{TaskStopped, run_task},
     tasks::archive_scan::{ArchiveScanTask, ScanReporter, ScanResult},
     types::{ArchiveAcquisitionContract, PrtsData},
-    window::{self, ForegroundGuard},
+    windows_ops::{self, window::ForegroundGuard},
 };
 
 /// 推送给前端的应用状态。
@@ -199,7 +199,7 @@ impl Controller {
                 };
 
                 // 扫描档案库任务需要点击游戏窗口，先确保窗口在前台（失败不阻断）
-                if let Err(e) = window::ensure_foreground_and_topmost(session.hwnd) {
+                if let Err(e) = windows_ops::window::ensure_foreground_and_topmost(session.hwnd) {
                     warn!("无法将游戏窗口置于前台: {e:#}，继续尝试执行任务");
                 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -32,24 +32,15 @@ use std::fs;
 use std::sync::atomic::{AtomicBool, AtomicU32};
 use std::sync::{Arc, Mutex, mpsc};
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result};
 use rapidocr_core::config::PipelineConfig;
 use tauri::Manager;
 use tracing::{info, warn};
-use windows::Win32::Foundation::HWND;
 
 use crate::{
     app_paths::AppPaths, controller::Controller, data::AppData, ocr::OcrEngine,
-    scene::create_scene_manager, window::ForegroundGuard,
+    scene::create_scene_manager,
 };
-
-/// 获取 OEA 主窗口的原生窗口句柄（用于前台窗口判定）。
-fn get_oea_hwnd(app_handle: &tauri::AppHandle) -> Result<HWND> {
-    let window = app_handle
-        .get_webview_window("main")
-        .ok_or_else(|| anyhow!("未找到 OEA 主窗口"))?;
-    Ok(window.hwnd()?)
-}
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -117,7 +108,7 @@ fn setup_app(app: &mut tauri::App) -> Result<()> {
     let (logger_guard, log_rx) = logger::init(&app_paths.logs_dir());
 
     // 设置线程 DPI 感知上下文，确保截图器获取的窗口客户区坐标与实际像素一致。
-    window::set_thread_dpi_awareness_context();
+    windows_ops::window::set_thread_dpi_awareness_context();
 
     // WebView2 缺失时自动下载引导程序并安装。
     webview2::ensure_installed(&app_paths.cache_dir()).inspect_err(|e| warn!("{e:#}"))?;
@@ -161,8 +152,8 @@ fn setup_app(app: &mut tauri::App) -> Result<()> {
     let scenes = Arc::new(create_scene_manager());
 
     // 开始监听热键
-    let oea_hwnd = get_oea_hwnd(app.handle())?;
-    let foreground = ForegroundGuard::new(oea_hwnd);
+    let oea_window = windows_ops::window::get_app_window(app.handle())?;
+    let foreground = windows_ops::window::ForegroundGuard::new(oea_window);
     let hotkey_rx = hotkey::listen()?;
 
     // 状态标志（Controller 唯一归属）

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -20,16 +20,18 @@ use std::time::Duration;
 use anyhow::Result;
 use image::{DynamicImage, RgbaImage, imageops};
 use imageproc::contrast::ThresholdType;
-use windows::Win32::Foundation::HWND;
 
 use crate::{
-    input::{Contact, InputBase},
     ocr::{OcrEngine, text_detection},
     resolution::GameResolution,
-    screencap::ScreencapBase,
     task::TaskStopped,
     template_matching::{MatchResult, TemplateManager},
     utils::{point::Point2D, region::Region2D},
+    windows_ops::{
+        WindowHandle,
+        capture::ScreencapBase,
+        input::{Contact, InputBase},
+    },
 };
 
 /// 停止令牌：热键 / 命令通过它请求中断，Session 每次操作前轮询。
@@ -38,7 +40,7 @@ pub type StopToken = Arc<AtomicBool>;
 /// 游戏会话：一次游戏操作（扫描档案库任务）的统一上下文。
 ///
 /// # Send 安全性
-/// `Session` 持有 Win32 句柄（`HWND` 内部为裸指针），不自动 `Send`。
+/// `Session` 持有非拥有型窗口句柄，不自动 `Send`。
 /// 窗口句柄在 OS 层面对线程无亲和性，且本类型始终由调用方以 `&mut`
 /// 串行使用（同一时刻仅一个线程访问），因此跨线程移动是安全的。
 /// 若未来有人破坏"单线程串行使用"这一前提，本 unsafe 承诺即失效。
@@ -46,7 +48,7 @@ unsafe impl Send for Session {}
 
 pub struct Session {
     /// 游戏窗口句柄（前台判定 / 日志用）
-    pub hwnd: HWND,
+    pub hwnd: WindowHandle,
     /// 游戏实际分辨率（仅支持 16:9）
     pub resolution: GameResolution,
     /// 截图器（可运行时替换，扩展点）
@@ -65,7 +67,7 @@ impl Session {
     /// 创建会话（由 [`crate::connect::connect_to_game`] 组装）。
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        hwnd: HWND,
+        hwnd: WindowHandle,
         screencap: Box<dyn ScreencapBase>,
         input: Box<dyn InputBase>,
         ocr: Arc<Mutex<OcrEngine>>,

--- a/src-tauri/src/tasks/screenshot.rs
+++ b/src-tauri/src/tasks/screenshot.rs
@@ -5,7 +5,7 @@ use base64::Engine;
 use image::{ImageFormat, imageops};
 use serde::Deserialize;
 
-use crate::{screencap::PrintWindowScreencap, window};
+use crate::windows_ops;
 
 /// 截图编码格式（与前端 `ScreenshotFormat` 对应，值为小写字符串）。
 #[derive(Debug, Clone, Copy, Deserialize)]
@@ -30,14 +30,14 @@ impl ScreenshotFormat {
 /// 截图的实际实现（返回 anyhow 错误，由命令层转换为 `String` 供 Tauri IPC 使用）。
 pub fn capture_screenshot(width: u32, height: u32, format: ScreenshotFormat) -> Result<String> {
     // 1. 定位游戏窗口（PrintWindow 可捕获非最小化后台窗口）
-    let hwnd = window::get_window_by_title(
-        Some(window::ENDFIELD_WINDOW_CLASS),
-        Some(window::ENDFIELD_WINDOW_TITLE),
+    let hwnd = windows_ops::window::get_window_by_title(
+        Some(windows_ops::window::ENDFIELD_WINDOW_CLASS),
+        Some(windows_ops::window::ENDFIELD_WINDOW_TITLE),
     )
     .context("未找到游戏窗口")?;
 
     // 2. 截图
-    let mut screencap = PrintWindowScreencap::new(hwnd);
+    let mut screencap = windows_ops::capture::PrintWindowScreencap::new(hwnd);
     let raw = screencap.screencap().context("截图失败")?;
 
     // 3. 缩放到指定尺寸

--- a/src-tauri/src/windows_ops/details/capture/base.rs
+++ b/src-tauri/src/windows_ops/details/capture/base.rs
@@ -1,11 +1,10 @@
+use crate::utils::region::Region2D;
+use crate::windows_ops::WindowHandle;
 use anyhow::Result;
 use image::{RgbaImage, imageops};
-use windows::Win32::Foundation::HWND;
-
-use crate::utils::region::Region2D;
 
 pub trait ScreencapBase: Send {
-    fn new(hwnd: HWND) -> Self
+    fn new(window: WindowHandle) -> Self
     where
         Self: Sized;
 

--- a/src-tauri/src/windows_ops/details/capture/desktop_dup.rs
+++ b/src-tauri/src/windows_ops/details/capture/desktop_dup.rs
@@ -16,6 +16,7 @@ use windows::Win32::Graphics::Gdi::{HMONITOR, MONITOR_DEFAULTTONEAREST, MonitorF
 use windows::core::Interface;
 
 use super::base::ScreencapBase;
+use crate::windows_ops::WindowHandle;
 
 // AcquireNextFrame 的超时参数
 const ACQUIRE_TIMEOUT: u32 = 2000;
@@ -35,9 +36,9 @@ pub struct DesktopDupScreencap {
 }
 
 impl DesktopDupScreencap {
-    pub fn new(hwnd: HWND) -> Self {
+    pub fn new(window: WindowHandle) -> Self {
         Self {
-            hwnd,
+            hwnd: window.0,
             d3d_device: None,
             d3d_context: None,
             dxgi_factory: None,
@@ -399,8 +400,8 @@ impl DesktopDupScreencap {
 unsafe impl Send for DesktopDupScreencap {}
 
 impl ScreencapBase for DesktopDupScreencap {
-    fn new(hwnd: HWND) -> Self {
-        Self::new(hwnd)
+    fn new(window: WindowHandle) -> Self {
+        Self::new(window)
     }
     fn screencap(&mut self) -> Result<RgbaImage> {
         self.screencap()

--- a/src-tauri/src/windows_ops/details/capture/desktop_dup_window.rs
+++ b/src-tauri/src/windows_ops/details/capture/desktop_dup_window.rs
@@ -6,6 +6,7 @@ use windows::Win32::UI::WindowsAndMessaging::GetClientRect;
 
 use super::base::ScreencapBase;
 use super::desktop_dup::DesktopDupScreencap;
+use crate::windows_ops::WindowHandle;
 
 /// 基于 Desktop Duplication 的窗口截图器
 /// 先截取全屏，再根据窗口客户区坐标裁剪
@@ -15,10 +16,10 @@ pub struct DesktopDupWindowScreencap {
 }
 
 impl DesktopDupWindowScreencap {
-    pub fn new(hwnd: HWND) -> Self {
+    pub fn new(window: WindowHandle) -> Self {
         Self {
-            hwnd,
-            inner: DesktopDupScreencap::new(hwnd),
+            hwnd: window.0,
+            inner: DesktopDupScreencap::new(window),
         }
     }
 
@@ -118,8 +119,8 @@ impl DesktopDupWindowScreencap {
 unsafe impl Send for DesktopDupWindowScreencap {}
 
 impl ScreencapBase for DesktopDupWindowScreencap {
-    fn new(hwnd: HWND) -> Self {
-        Self::new(hwnd)
+    fn new(window: WindowHandle) -> Self {
+        Self::new(window)
     }
 
     fn screencap(&mut self) -> Result<RgbaImage> {

--- a/src-tauri/src/windows_ops/details/capture/frame_pool.rs
+++ b/src-tauri/src/windows_ops/details/capture/frame_pool.rs
@@ -32,6 +32,7 @@ use windows::Win32::UI::WindowsAndMessaging::{
 use windows::core::Interface;
 
 use super::base::ScreencapBase;
+use crate::windows_ops::WindowHandle;
 
 /// FramePool 截图器
 pub struct FramePoolScreencap {
@@ -53,8 +54,8 @@ pub struct FramePoolScreencap {
 unsafe impl Send for FramePoolScreencap {}
 
 impl ScreencapBase for FramePoolScreencap {
-    fn new(hwnd: HWND) -> Self {
-        Self::new(hwnd)
+    fn new(window: WindowHandle) -> Self {
+        Self::new(window)
     }
     fn screencap(&mut self) -> Result<RgbaImage> {
         self.screencap()
@@ -62,9 +63,9 @@ impl ScreencapBase for FramePoolScreencap {
 }
 
 impl FramePoolScreencap {
-    pub fn new(hwnd: HWND) -> Self {
+    pub fn new(window: WindowHandle) -> Self {
         Self {
-            hwnd,
+            hwnd: window.0,
             d3d_device: None,
             d3d_context: None,
             dxgi_swap_chain: None,

--- a/src-tauri/src/windows_ops/details/capture/gdi.rs
+++ b/src-tauri/src/windows_ops/details/capture/gdi.rs
@@ -10,14 +10,15 @@ use windows::Win32::UI::WindowsAndMessaging::GetClientRect;
 
 use super::base::ScreencapBase;
 use crate::utils::region::Region2D;
+use crate::windows_ops::WindowHandle;
 
 pub struct GdiScreencap {
     hwnd: HWND,
 }
 
 impl GdiScreencap {
-    pub fn new(hwnd: HWND) -> Self {
-        Self { hwnd }
+    pub fn new(window: WindowHandle) -> Self {
+        Self { hwnd: window.0 }
     }
 
     pub fn screencap(&mut self) -> Result<RgbaImage> {
@@ -97,8 +98,8 @@ impl GdiScreencap {
 unsafe impl Send for GdiScreencap {}
 
 impl ScreencapBase for GdiScreencap {
-    fn new(hwnd: HWND) -> Self {
-        Self::new(hwnd)
+    fn new(window: WindowHandle) -> Self {
+        Self::new(window)
     }
 
     fn screencap(&mut self) -> Result<RgbaImage> {

--- a/src-tauri/src/windows_ops/details/capture/print_window.rs
+++ b/src-tauri/src/windows_ops/details/capture/print_window.rs
@@ -11,6 +11,7 @@ use windows::Win32::UI::WindowsAndMessaging::GetClientRect;
 
 use super::base::ScreencapBase;
 use crate::utils::region::Region2D;
+use crate::windows_ops::WindowHandle;
 
 // PW_RENDERFULLCONTENT (0x2): 捕获非最小化后台窗口
 const PW_RENDERFULLCONTENT: PRINT_WINDOW_FLAGS = PRINT_WINDOW_FLAGS(0x2_u32);
@@ -20,8 +21,8 @@ pub struct PrintWindowScreencap {
 }
 
 impl PrintWindowScreencap {
-    pub fn new(hwnd: HWND) -> Self {
-        Self { hwnd }
+    pub fn new(window: WindowHandle) -> Self {
+        Self { hwnd: window.0 }
     }
 
     pub fn screencap(&mut self) -> Result<RgbaImage> {
@@ -282,8 +283,8 @@ impl PrintWindowScreencap {
 unsafe impl Send for PrintWindowScreencap {}
 
 impl ScreencapBase for PrintWindowScreencap {
-    fn new(hwnd: HWND) -> Self {
-        Self::new(hwnd)
+    fn new(window: WindowHandle) -> Self {
+        Self::new(window)
     }
 
     fn screencap(&mut self) -> Result<RgbaImage> {

--- a/src-tauri/src/windows_ops/details/capture/screen_dc.rs
+++ b/src-tauri/src/windows_ops/details/capture/screen_dc.rs
@@ -10,14 +10,15 @@ use windows::Win32::UI::WindowsAndMessaging::GetClientRect;
 
 use super::base::ScreencapBase;
 use crate::utils::region::Region2D;
+use crate::windows_ops::WindowHandle;
 
 pub struct ScreenDCScreencap {
     hwnd: HWND,
 }
 
 impl ScreenDCScreencap {
-    pub fn new(hwnd: HWND) -> Self {
-        Self { hwnd }
+    pub fn new(window: WindowHandle) -> Self {
+        Self { hwnd: window.0 }
     }
 
     pub fn screencap(&mut self) -> Result<RgbaImage> {
@@ -124,8 +125,8 @@ impl ScreenDCScreencap {
 unsafe impl Send for ScreenDCScreencap {}
 
 impl ScreencapBase for ScreenDCScreencap {
-    fn new(hwnd: HWND) -> Self {
-        Self::new(hwnd)
+    fn new(window: WindowHandle) -> Self {
+        Self::new(window)
     }
 
     fn screencap(&mut self) -> Result<RgbaImage> {

--- a/src-tauri/src/windows_ops/details/input/base.rs
+++ b/src-tauri/src/windows_ops/details/input/base.rs
@@ -1,13 +1,12 @@
 use std::{thread, time::Duration};
 
-use anyhow::Result;
-use windows::Win32::Foundation::HWND;
-
 use super::input_utils::Contact;
 use crate::utils::point::Point2D;
+use crate::windows_ops::WindowHandle;
+use anyhow::Result;
 
 pub trait InputBase: Send {
-    fn new(hwnd: HWND, block_input: bool) -> Self
+    fn new(window: WindowHandle, block_input: bool) -> Self
     where
         Self: Sized;
 

--- a/src-tauri/src/windows_ops/details/input/seize.rs
+++ b/src-tauri/src/windows_ops/details/input/seize.rs
@@ -14,6 +14,7 @@ use windows::Win32::UI::WindowsAndMessaging::{
 
 use super::{base::InputBase, input_utils::Contact};
 use crate::utils::point::Point2D;
+use crate::windows_ops::WindowHandle;
 use crate::windows_ops::window::ensure_foreground_and_topmost;
 
 pub struct SeizeInput {
@@ -30,9 +31,9 @@ impl Drop for SeizeInput {
 
 impl SeizeInput {
     /// 创建输入器（物理输入，`block_input` 为是否在操作期间屏蔽真实键盘鼠标）。
-    pub fn new(hwnd: HWND, block_input: bool) -> Self {
+    pub fn new(window: WindowHandle, block_input: bool) -> Self {
         Self {
-            hwnd,
+            hwnd: window.0,
             block_input,
             last_pos: None,
         }
@@ -144,7 +145,7 @@ impl SeizeInput {
     }
 
     fn ensure_foreground(&self) -> Result<()> {
-        ensure_foreground_and_topmost(self.hwnd)
+        ensure_foreground_and_topmost(WindowHandle(self.hwnd))
     }
 
     fn get_target_pos(&self) -> (i32, i32) {
@@ -339,8 +340,8 @@ impl SeizeInput {
 unsafe impl Send for SeizeInput {}
 
 impl InputBase for SeizeInput {
-    fn new(hwnd: HWND, block_input: bool) -> Self {
-        Self::new(hwnd, block_input)
+    fn new(window: WindowHandle, block_input: bool) -> Self {
+        Self::new(window, block_input)
     }
 
     fn touch_down(&mut self, contact: Contact, point: Point2D<i32>) -> Result<()> {

--- a/src-tauri/src/windows_ops/details/window/foreground.rs
+++ b/src-tauri/src/windows_ops/details/window/foreground.rs
@@ -4,9 +4,8 @@
 //! 避免在其他程序中误触发扫描 / 启动；`Alt+Delete` 退出热键全局生效，
 //! 不受本守卫限制。
 
-use windows::Win32::Foundation::HWND;
-
 use super::{get_foreground_window, get_window_by_title};
+use crate::windows_ops::WindowHandle;
 
 /// 终末地游戏窗口标题
 pub const ENDFIELD_WINDOW_TITLE: &str = "Endfield";
@@ -17,20 +16,20 @@ pub const ENDFIELD_WINDOW_CLASS: &str = "UnityWndClass";
 ///
 /// 仅持有窗口句柄（裸指针封装），且只读、不修改窗口。访问被串行化到热键
 /// 消费线程（`Controller::spawn_hotkey_loop`），与 [`crate::screencap`] 中
-/// 其它持有 HWND 的类型采用相同的 Send/Sync 约定。
+/// 其它持有原生窗口句柄的类型采用相同的 Send/Sync 约定。
 pub struct ForegroundGuard {
     /// OEA 自身主窗口句柄
-    oea_hwnd: HWND,
+    oea_window: WindowHandle,
 }
 
-// HWND 为 `*mut c_void` 封装，本身非 Send/Sync，需手动声明（调用方串行化访问）
+// 原生窗口句柄本身非 Send/Sync，需手动声明（调用方串行化访问）。
 unsafe impl Send for ForegroundGuard {}
 unsafe impl Sync for ForegroundGuard {}
 
 impl ForegroundGuard {
     /// 创建守卫，绑定 OEA 自身主窗口句柄。
-    pub fn new(oea_hwnd: HWND) -> Self {
-        Self { oea_hwnd }
+    pub fn new(oea_window: WindowHandle) -> Self {
+        Self { oea_window }
     }
 
     /// 判断当前前台窗口是否为 OEA 自身或终末地游戏窗口。
@@ -41,7 +40,7 @@ impl ForegroundGuard {
         let foreground = get_foreground_window();
 
         // OEA 自身窗口在前台
-        if foreground == self.oea_hwnd {
+        if foreground == self.oea_window {
             return true;
         }
 

--- a/src-tauri/src/windows_ops/details/window/get_window.rs
+++ b/src-tauri/src/windows_ops/details/window/get_window.rs
@@ -1,13 +1,22 @@
-use anyhow::Result;
-use windows::Win32::Foundation::HWND;
+use anyhow::{Result, anyhow};
+use tauri::Manager;
 use windows::Win32::UI::WindowsAndMessaging::{FindWindowW, GetForegroundWindow};
 use windows::core::PCWSTR;
 
-pub fn get_foreground_window() -> HWND {
-    unsafe { GetForegroundWindow() }
+use crate::windows_ops::WindowHandle;
+
+pub fn get_app_window(app_handle: &tauri::AppHandle) -> Result<WindowHandle> {
+    let window = app_handle
+        .get_webview_window("main")
+        .ok_or_else(|| anyhow!("未找到 OEA 主窗口"))?;
+    Ok(WindowHandle(window.hwnd()?))
 }
 
-pub fn get_window_by_title(class_name: Option<&str>, title: Option<&str>) -> Result<HWND> {
+pub fn get_foreground_window() -> WindowHandle {
+    WindowHandle(unsafe { GetForegroundWindow() })
+}
+
+pub fn get_window_by_title(class_name: Option<&str>, title: Option<&str>) -> Result<WindowHandle> {
     let class_wide = class_name.map(|s| {
         s.encode_utf16()
             .chain(std::iter::once(0))
@@ -23,7 +32,7 @@ pub fn get_window_by_title(class_name: Option<&str>, title: Option<&str>) -> Res
     let lpwindowname = title_wide.map(|v| PCWSTR::from_raw(v.as_ptr()));
 
     let hwnd = unsafe { FindWindowW(lpclassname.as_ref(), lpwindowname.as_ref()) }?;
-    Ok(hwnd)
+    Ok(WindowHandle(hwnd))
 }
 
 #[cfg(test)]

--- a/src-tauri/src/windows_ops/details/window/hdr.rs
+++ b/src-tauri/src/windows_ops/details/window/hdr.rs
@@ -14,15 +14,18 @@ use windows::Win32::Devices::Display::{
     DISPLAYCONFIG_SOURCE_MODE, DisplayConfigGetDeviceInfo, GetDisplayConfigBufferSizes,
     QDC_ONLY_ACTIVE_PATHS, QueryDisplayConfig,
 };
-use windows::Win32::Foundation::{ERROR_INSUFFICIENT_BUFFER, ERROR_SUCCESS, HWND};
+use windows::Win32::Foundation::{ERROR_INSUFFICIENT_BUFFER, ERROR_SUCCESS};
 use windows::Win32::Graphics::Gdi::{
     GetMonitorInfoW, MONITOR_DEFAULTTONEAREST, MONITORINFOEXW, MonitorFromWindow,
 };
 
+use crate::windows_ops::WindowHandle;
+
 /// 判断指定窗口所在显示器是否开启了 HDR。
 ///
 /// 检测失败（API 不可用 / 查询出错）时返回 `Err`，由调用方决定是否阻断任务。
-pub fn is_hdr_enabled_on_window_monitor(hwnd: HWND) -> Result<bool> {
+pub fn is_hdr_enabled_on_window_monitor(window: WindowHandle) -> Result<bool> {
+    let hwnd = window.0;
     // 1. 定位窗口所在显示器，读取其桌面矩形
     let monitor = unsafe { MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST) };
     if monitor.is_invalid() {

--- a/src-tauri/src/windows_ops/details/window/window_info.rs
+++ b/src-tauri/src/windows_ops/details/window/window_info.rs
@@ -1,5 +1,5 @@
 use anyhow::{Result, bail};
-use windows::Win32::Foundation::{HWND, POINT, RECT};
+use windows::Win32::Foundation::{POINT, RECT};
 use windows::Win32::Graphics::Gdi::ClientToScreen;
 use windows::Win32::UI::WindowsAndMessaging::{
     GWL_STYLE, GetClassNameW, GetClientRect, GetWindowLongPtrW, GetWindowTextLengthW,
@@ -7,8 +7,10 @@ use windows::Win32::UI::WindowsAndMessaging::{
 };
 
 use crate::utils::{point::Point2D, region::Region2D};
+use crate::windows_ops::WindowHandle;
 
-pub fn get_window_title(hwnd: HWND) -> Result<String> {
+pub fn get_window_title(window: WindowHandle) -> Result<String> {
+    let hwnd = window.0;
     let length = unsafe { GetWindowTextLengthW(hwnd) };
     if length == 0 {
         bail!("Failed to get window title");
@@ -21,19 +23,22 @@ pub fn get_window_title(hwnd: HWND) -> Result<String> {
     Ok(title)
 }
 
-pub fn get_client_rect(hwnd: HWND) -> Result<Region2D<i32>> {
+pub fn get_client_rect(window: WindowHandle) -> Result<Region2D<i32>> {
+    let hwnd = window.0;
     let mut rect = RECT::default();
     unsafe { GetClientRect(hwnd, &mut rect) }?;
     Ok(rect.into())
 }
 
-pub fn client_to_screen(hwnd: HWND, point: Point2D<i32>) -> Result<Point2D<i32>> {
+pub fn client_to_screen(window: WindowHandle, point: Point2D<i32>) -> Result<Point2D<i32>> {
+    let hwnd = window.0;
     let mut point = POINT::from(point);
     unsafe { ClientToScreen(hwnd, &mut point) }.ok()?;
     Ok(point.into())
 }
 
-pub fn get_window_class_name(hwnd: HWND) -> Result<String> {
+pub fn get_window_class_name(window: WindowHandle) -> Result<String> {
+    let hwnd = window.0;
     let mut buffer = vec![0u16; 256];
     let length = unsafe { GetClassNameW(hwnd, &mut buffer) };
     if length == 0 {
@@ -44,6 +49,7 @@ pub fn get_window_class_name(hwnd: HWND) -> Result<String> {
     Ok(class_name)
 }
 
-pub fn is_fullscreen(hwnd: HWND) -> bool {
+pub fn is_fullscreen(window: WindowHandle) -> bool {
+    let hwnd = window.0;
     (unsafe { GetWindowLongPtrW(hwnd, GWL_STYLE) } as u32) & WS_POPUP.0 != 0
 }

--- a/src-tauri/src/windows_ops/details/window/window_operation.rs
+++ b/src-tauri/src/windows_ops/details/window/window_operation.rs
@@ -1,5 +1,5 @@
 use anyhow::{Result, bail};
-use windows::Win32::Foundation::{HWND, POINT, RECT};
+use windows::Win32::Foundation::{POINT, RECT};
 use windows::Win32::Graphics::Gdi::{
     ClientToScreen, GetMonitorInfoW, MONITOR_DEFAULTTONEAREST, MONITORINFO, MonitorFromWindow,
 };
@@ -12,6 +12,8 @@ use windows::Win32::UI::WindowsAndMessaging::{
     SWP_SHOWWINDOW, SetForegroundWindow, SetWindowPos, ShowWindow,
 };
 
+use crate::windows_ops::WindowHandle;
+
 /// 设置当前线程的 DPI 感知上下文为 Per Monitor v2
 pub fn set_thread_dpi_awareness_context() -> DPI_AWARENESS_CONTEXT {
     unsafe { SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2) }
@@ -19,7 +21,8 @@ pub fn set_thread_dpi_awareness_context() -> DPI_AWARENESS_CONTEXT {
 
 // 窗口激活并置顶工具函数（强化版本，用于需要前台的物理输入方式）
 // 用于 LegacyEventInput 和 SeizeInput，因为它们使用 SendInput/mouse_event 等物理输入 API
-pub fn ensure_foreground_and_topmost(hwnd: HWND) -> Result<()> {
+pub fn ensure_foreground_and_topmost(window: WindowHandle) -> Result<()> {
+    let hwnd = window.0;
     if hwnd.is_invalid() {
         bail!("hwnd is invalid");
     }
@@ -50,7 +53,8 @@ pub fn ensure_foreground_and_topmost(hwnd: HWND) -> Result<()> {
 ///
 /// 连接游戏时调用：窗口最小化时 [`ensure_window_on_screen`] 会跳过调整，
 /// 需先恢复窗口才能正确获取并调整客户区。
-pub fn restore_window_if_minimized(hwnd: HWND) -> Result<()> {
+pub fn restore_window_if_minimized(window: WindowHandle) -> Result<()> {
+    let hwnd = window.0;
     if hwnd.is_invalid() || !unsafe { IsWindow(Some(hwnd)) }.as_bool() {
         bail!("Invalid window handle");
     }
@@ -65,7 +69,8 @@ pub fn restore_window_if_minimized(hwnd: HWND) -> Result<()> {
 /// Ensure the window's client area is fully visible on the monitor.
 /// If the window extends beyond the monitor bounds, move it back.
 /// If the client area is larger than the monitor, resize the window.
-pub fn ensure_window_on_screen(hwnd: HWND) -> Result<()> {
+pub fn ensure_window_on_screen(window: WindowHandle) -> Result<()> {
+    let hwnd = window.0;
     if hwnd.is_invalid() || !unsafe { IsWindow(Some(hwnd)) }.as_bool() {
         bail!("Invalid window handle");
     }

--- a/src-tauri/src/windows_ops/mod.rs
+++ b/src-tauri/src/windows_ops/mod.rs
@@ -4,7 +4,22 @@
 //! `details` 区域。现阶段 topic 接口仍保留已有的 raw Windows 类型，后续
 //! stack 层再逐步替换这些接口。
 
+use windows::Win32::Foundation::HWND;
+
 mod details;
+
+/// OEA 持有的非拥有型窗口句柄。
+///
+/// 原生表示保持在 `windows_ops` 内；本类型不承诺跨线程安全。
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct WindowHandle(HWND);
+
+impl WindowHandle {
+    /// 句柄是否无效。
+    pub fn is_invalid(self) -> bool {
+        self.0.is_invalid()
+    }
+}
 
 pub mod admin {
     pub use super::details::admin::*;
@@ -32,4 +47,14 @@ pub mod webview2 {
 
 pub mod window {
     pub use super::details::window::*;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_native_handle_is_invalid() {
+        assert!(WindowHandle(HWND::default()).is_invalid());
+    }
 }

--- a/src-tauri/src/windows_ops/mod.rs
+++ b/src-tauri/src/windows_ops/mod.rs
@@ -1,8 +1,8 @@
 //! Windows 操作的所有权根。
 //!
 //! 公开 topic 模块只负责提供稳定的 OEA 模块路径；具体实现集中在私有的
-//! `details` 区域。现阶段 topic 接口仍保留已有的 raw Windows 类型，后续
-//! stack 层再逐步替换这些接口。
+//! `details` 区域。`HWND` 已由 [`WindowHandle`] 封装；topic 接口中的其余
+//! raw Windows 类型由后续 stack 层继续替换。
 
 use windows::Win32::Foundation::HWND;
 
@@ -47,14 +47,4 @@ pub mod webview2 {
 
 pub mod window {
     pub use super::details::window::*;
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn default_native_handle_is_invalid() {
-        assert!(WindowHandle(HWND::default()).is_invalid());
-    }
 }


### PR DESCRIPTION
> This message is generated by AI.

PR #14 已经把 Windows-heavy 实现集中到 `windows_ops::details`，但 `HWND` 仍通过窗口查找、应用窗口获取、游戏会话、截图和输入接口泄漏给外部调用方。这样调用方仍需理解原生句柄表示，也无法在后续层继续收紧 Windows 边界。

因此这一层引入单字段且字段私有的 `WindowHandle`，让 window topic 统一产生 OEA 自有句柄，并一次性迁移所有 handle 消费接口和调用方。`WindowHandle` 仅提供 `is_invalid()`，没有 raw accessor、转换 trait 或全局 `Send` / `Sync` 承诺；现有 `Session`、截图器、输入器和前台守卫继续保留各自原有的窄线程安全承诺。

本层保持原函数控制流、错误传播、warning 后继续和 fallback 行为，也不改变生产截图与输入实现。几何、Windows 消息、flags 和剩余调用路径留给后续 stack 层。

## 验证

- `cargo fmt --all -- --check`
- `HWND` 在 `windows_ops` 外为 0 matches
- public handle 接口不再接收或返回 `HWND`
- `cargo xwin check --target x86_64-pc-windows-msvc --all-targets`
- `cargo xwin clippy --target x86_64-pc-windows-msvc --all-targets -- -D warnings`
- `cargo xwin build --target x86_64-pc-windows-msvc`

Windows 测试目标已编译，但本机为 macOS，未执行窗口发现、截图、输入、前台控制或其他 Windows runtime 行为。

Closes #11

## 由 Sourcery 提供的摘要

为原生 Win32 窗口句柄引入不透明的 `WindowHandle` 包装器，并将窗口、截图、输入、前台和会话相关的代码路径迁移为使用它来替代 `HWND`。

新功能：
- 新增 `WindowHandle` 类型，作为内部使用、非线程安全的 Win32 `HWND` 值包装器，并提供最小化的有效性校验 API。
- 新增辅助工具，通过 Tauri 的 `AppHandle` 使用新的 `WindowHandle` API 获取主应用窗口句柄。

增强改进：
- 重构窗口发现、前台保护、HDR 检查以及 DPI 感知设置逻辑，使其归类到 `windows_ops` 模块下，并改为使用 `WindowHandle` 而非原始 `HWND`。
- 更新截图与输入抽象（`ScreencapBase`、`InputBase` 及其具体实现）以及 `Session`，使其基于 `WindowHandle` 运行，从而收紧对原始 Windows 类型的暴露。
- 调整控制器、连接流程和截图任务以使用 `windows_ops` 的入口和新的句柄抽象，避免在高层直接使用 `HWND`。

测试：
- 新增单元测试，确保由 `WindowHandle` 包装的默认原生 `HWND` 会被视为无效。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an opaque WindowHandle wrapper for native Win32 window handles and migrate window, screenshot, input, foreground, and session code paths to use it instead of HWND.

New Features:
- Add WindowHandle type as an internal, non-thread-safe wrapper for Win32 HWND values, with minimal validity checking APIs.
- Add helper to get the main application window handle via Tauri AppHandle using the new WindowHandle API.

Enhancements:
- Refactor window discovery, foreground guarding, HDR checks, and DPI-awareness setup to live under the windows_ops module and consume WindowHandle instead of raw HWND.
- Update screencap and input abstractions (ScreencapBase, InputBase, concrete implementations) and Session to operate on WindowHandle, tightening the exposure of raw Windows types.
- Adjust controller, connect flow, and screenshot tasks to use windows_ops entry points and the new handle abstraction, avoiding direct HWND usage in higher layers.

Tests:
- Add a unit test ensuring default native HWND wrapped by WindowHandle is treated as invalid.

</details>