### PR TITLE
refactor: 提取扫描任务运行时

### DIFF
--- a/src-tauri/src/controller.rs
+++ b/src-tauri/src/controller.rs
@@ -1,45 +1,33 @@
 //! 应用控制器（Tauri 托管状态）。
 //!
 //! 职责边界：
-//! - **状态机**：`running`（CAS 防重入启动）与 `stop`（秒停）两个原子标志的**唯一归属**；
-//! - **线程编排**：扫描档案库任务线程、热键消费线程、日志 / 结果转发线程；
+//! - **应用编排**：为扫描任务创建运行上下文；
+//! - **线程编排**：热键消费线程、日志 / 结果转发线程；
 //! - **热键动作分发**（应用层）：键位常量（[`TOGGLE_MAIN_TASK_HOTKEY`] / [`EXIT_HOTKEY`]）+ 前台窗口过滤 + [`Controller::spawn_hotkey_loop`]；
 //!
-//! 依赖方向：应用层 → 领域层（connect/session/scene/task）→ 基础设施层。
+//! 扫描任务的状态机与执行线程由 [`ScanRuntime`] 拥有。
 
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, mpsc};
 use std::thread;
 
-use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter};
 use tracing::{debug, error, info, warn};
 
 use crate::{
     app_paths::AppPaths,
     config::OeaConfig,
-    connect::connect_to_game,
     data::AppData,
     logger::LogEntry,
     ocr::OcrEngine,
+    scan_runtime::{ScanRunContext, ScanRuntime},
     scene::SceneManager,
-    sound,
-    task::{TaskStopped, run_task},
-    tasks::archive_scan::{ArchiveScanTask, ScanReporter, ScanResult},
+    tasks::archive_scan::{ScanReporter, ScanResult},
     types::{ArchiveContract, PrtsData},
     windows_ops,
 };
 
 /// 推送给前端的应用状态。
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct AppStatus {
-    /// 扫描档案库任务是否正在运行
-    pub running: bool,
-    /// 扫描档案库任务结束时的失败原因（仅失败时随结束状态推送一次；成功 / 被停止 / 查询状态时为 `None`）
-    #[serde(default)]
-    pub scan_error: Option<String>,
-}
+pub use crate::scan_runtime::AppStatus;
 
 /// 引号 `'` → 切换扫描档案库任务
 pub const TOGGLE_MAIN_TASK_HOTKEY: windows_ops::hotkey::KeyEvent = windows_ops::hotkey::KeyEvent {
@@ -59,20 +47,18 @@ pub struct Controller {
     /// 应用根目录
     app_path: AppPaths,
     /// 应用配置
-    oea_config: Mutex<OeaConfig>,
+    oea_config: Arc<Mutex<OeaConfig>>,
     /// 共享 OCR 引擎（跨会话复用模型）
     ocr: Arc<Mutex<OcrEngine>>,
     /// 场景管理器（本游戏全部场景，跨线程共享只读）
     scenes: Arc<SceneManager>,
-    /// 停止标志（独立于锁：命令 / 热键均可快速请求停止，任务内部轮询）
-    stop: Arc<AtomicBool>,
-    /// 扫描档案库任务运行标志（CAS 占用防重入）
-    running: Arc<AtomicBool>,
+    /// 扫描档案库任务运行时
+    scan_runtime: Arc<ScanRuntime>,
     /// 扫描结果通道发送端（`Mutex` 同理：`Sender` 非 Sync）
     scan_tx: Mutex<mpsc::Sender<ScanResult>>,
     /// 前台窗口守卫（应用层过滤：分号/引号仅在前台为 OEA 或终末地时响应）
     foreground: windows_ops::window::ForegroundGuard,
-    /// Tauri 应用句柄（向前端 emit 事件）
+    /// Tauri 应用句柄（创建扫描运行上下文）
     handle: AppHandle,
     /// 静态数据（prts.json / 档案获取契约 / 纠错索引，启动时统一加载）
     app_data: AppData,
@@ -83,13 +69,12 @@ pub struct Controller {
 impl Controller {
     /// 创建控制器。
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
+    pub(crate) fn new(
         app_path: AppPaths,
-        oea_config: Mutex<OeaConfig>,
+        oea_config: Arc<Mutex<OeaConfig>>,
         ocr: Arc<Mutex<OcrEngine>>,
         scenes: Arc<SceneManager>,
-        stop: Arc<AtomicBool>,
-        running: Arc<AtomicBool>,
+        scan_runtime: Arc<ScanRuntime>,
         scan_tx: mpsc::Sender<ScanResult>,
         foreground: windows_ops::window::ForegroundGuard,
         handle: AppHandle,
@@ -101,8 +86,7 @@ impl Controller {
             oea_config,
             ocr,
             scenes,
-            stop,
-            running,
+            scan_runtime,
             scan_tx: Mutex::new(scan_tx),
             foreground,
             handle,
@@ -115,33 +99,18 @@ impl Controller {
         &self.app_path
     }
 
-    pub fn oea_config(&self) -> &Mutex<OeaConfig> {
+    pub fn oea_config(&self) -> &Arc<Mutex<OeaConfig>> {
         &self.oea_config
     }
 
     /// 读取当前状态（只读原子标志；失败原因不存储，由结束事件一次性推送）。
     pub fn get_status(&self) -> AppStatus {
-        AppStatus {
-            running: self.running.load(Ordering::Relaxed),
-            scan_error: None,
-        }
+        self.scan_runtime.status()
     }
 
     /// 创建扫描结果上报器（每次游戏操作一个，只负责转发结果）。
     fn reporter(&self) -> ScanReporter {
         ScanReporter::new(self.scan_tx.lock().unwrap().clone())
-    }
-
-    /// 播放扫描提示音（音量取配置；开始/自然完成播 enable，失败/被停止播 disable）。
-    fn play_scan_sound(&self, enable: bool) {
-        let volume = self
-            .oea_config()
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .sound_volume;
-        let name = if enable { "enable.wav" } else { "disable.wav" };
-        let path = self.app_path.resources_dir().join("sounds").join(name);
-        sound::play_wav(&path, volume);
     }
 
     /// 返回 prts.json 完整数据（供前端查询分类中文名 / 自动补全候选）。
@@ -158,93 +127,16 @@ impl Controller {
 
     /// 启动扫描档案库任务：CAS 占用运行标志 → 推送状态 → 后台线程执行。
     pub fn start_scan(self: &Arc<Self>) {
-        if self
-            .running
-            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-            .is_err()
-        {
-            warn!("扫描档案库任务正在运行中，忽略重复的启动请求");
-            return;
-        }
-        info!("收到启动扫描档案库任务请求");
-        // 启动状态不携带失败原因（失败原因仅在任务结束时推送一次）
-        self.emit_status(None);
-
-        let this = Arc::clone(self);
-        thread::Builder::new()
-            .name("oea-scan".to_string())
-            .spawn(move || {
-                // 任务开始时才连接游戏（游戏未打开则报错并复位）
-                let mut session = match connect_to_game(
-                    &this.ocr,
-                    &this.app_path.templates_dir(),
-                    this.stop.clone(),
-                ) {
-                    Ok(s) => s,
-                    Err(e) => {
-                        error!("连接游戏失败: {e:#}");
-                        this.play_scan_sound(false);
-                        this.finish_scan(Some(format!("连接游戏失败: {e:#}")));
-                        return;
-                    }
-                };
-
-                // 扫描档案库任务需要点击游戏窗口，先确保窗口在前台（失败不阻断）
-                if let Err(e) = windows_ops::window::ensure_foreground_and_topmost(session.hwnd) {
-                    warn!("无法将游戏窗口置于前台: {e:#}，继续尝试执行任务");
-                }
-
-                // 清除上一次可能残留的停止信号
-                session.reset_stop();
-
-                // 启动检查通过、任务真正开始执行前播放 enable 提示音
-                // （避免"启动后立即失败"时 enable/disable 两个音效同时播放）
-                this.play_scan_sound(true);
-
-                // 执行扫描档案库任务（阻塞，期间任务内部轮询停止标志）
-                let task = ArchiveScanTask::new(this.reporter(), this.app_data.correction());
-                let result = run_task(&task, &mut session, &this.scenes);
-
-                // 区分"被停止"与"出错"
-                match result {
-                    Ok(_) => {
-                        info!("========== 扫描档案库任务执行完毕 ==========");
-                        this.play_scan_sound(true);
-                        this.finish_scan(None);
-                    }
-                    Err(e) if e.downcast_ref::<TaskStopped>().is_some() => {
-                        info!("扫描档案库任务已被用户停止");
-                        this.play_scan_sound(false);
-                        this.finish_scan(None);
-                    }
-                    Err(e) => {
-                        error!("扫描档案库任务执行失败: {e:#}");
-                        this.play_scan_sound(false);
-                        this.finish_scan(Some(format!("扫描档案库任务执行失败: {e:#}")));
-                    }
-                }
-            })
-            .expect("启动扫描档案库任务线程失败");
-    }
-
-    /// 复位运行标志并推送"空闲"状态（携带本次任务的失败原因，无失败时为 `None`）。
-    fn finish_scan(&self, scan_error: Option<String>) {
-        self.running.store(false, Ordering::Relaxed);
-        self.emit_status(scan_error);
+        self.scan_runtime.start(|| self.scan_context());
     }
 
     /// 请求停止扫描档案库任务（原子置位，由任务内部轮询实现优雅停止）。
     pub fn stop_scan(&self) {
-        if !self.running.load(Ordering::Relaxed) {
-            warn!("扫描档案库任务未在运行，忽略停止请求");
-            return;
-        }
-        self.stop.store(true, Ordering::Relaxed);
-        info!("收到停止请求，正在停止扫描档案库任务...");
+        self.scan_runtime.stop();
     }
 
     pub fn toggle_scan(self: &Arc<Self>) {
-        if self.running.load(Ordering::Relaxed) {
+        if self.get_status().running {
             self.stop_scan();
         } else {
             self.start_scan();
@@ -257,7 +149,7 @@ impl Controller {
             warn!("正在安装更新，拒绝退出");
             return;
         }
-        self.stop.store(true, Ordering::Relaxed);
+        self.scan_runtime.request_stop_for_shutdown();
         info!("收到退出请求，正在退出程序...");
         self.handle.exit(0);
     }
@@ -314,14 +206,15 @@ impl Controller {
             .expect("启动扫描结果转发线程失败");
     }
 
-    /// 向前端推送当前状态（running 标志 + 本次任务结束时的失败原因）。
-    fn emit_status(&self, scan_error: Option<String>) {
-        let status = AppStatus {
-            running: self.running.load(Ordering::Relaxed),
-            scan_error,
-        };
-        if let Err(e) = self.handle.emit("app-status", &status) {
-            error!("向前端推送状态失败: {e}");
-        }
+    fn scan_context(&self) -> ScanRunContext {
+        ScanRunContext::new(
+            self.app_path.clone(),
+            Arc::clone(&self.oea_config),
+            Arc::clone(&self.ocr),
+            Arc::clone(&self.scenes),
+            self.app_data.correction(),
+            self.reporter(),
+            self.handle.clone(),
+        )
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ pub mod dpapi;
 pub mod logger;
 pub mod ocr;
 pub mod resolution;
+pub(crate) mod scan_runtime;
 pub mod scene;
 pub mod session;
 pub mod sound;
@@ -24,7 +25,6 @@ pub mod utils;
 pub mod windows_ops;
 
 use std::fs;
-use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex, mpsc};
 
 use anyhow::{Context, Result};
@@ -34,7 +34,7 @@ use tracing::{info, warn};
 
 use crate::{
     app_paths::AppPaths, controller::Controller, data::AppData, ocr::OcrEngine,
-    scene::create_scene_manager,
+    scan_runtime::ScanRuntime, scene::create_scene_manager,
 };
 
 #[cfg(target_os = "windows")]
@@ -167,7 +167,9 @@ fn setup_app(app: &mut tauri::App) -> Result<()> {
         .inspect_err(|e| warn!("{e:#}"))?;
 
     // 解析应用配置文件
-    let oea_config = config::load_oea_config(&app_paths.oea_config_file());
+    let oea_config = Arc::new(Mutex::new(config::load_oea_config(
+        &app_paths.oea_config_file(),
+    )));
 
     // 绿色便携：WebView2 用户数据目录放在应用目录内（默认会写入 `%LOCALAPPDATA%\<identifier>`），保证所有磁盘写入都限定在应用目录内。
     fs::create_dir_all(app_paths.webview_data_dir()).with_context(|| {
@@ -212,18 +214,15 @@ fn setup_app(app: &mut tauri::App) -> Result<()> {
     let foreground = windows_ops::window::ForegroundGuard::new(oea_window);
     let hotkey_rx = windows_ops::hotkey::listen()?;
 
-    // 状态标志（Controller 唯一归属）
-    let stop = Arc::new(AtomicBool::new(false));
-    let running = Arc::new(AtomicBool::new(false));
+    let scan_runtime = Arc::new(ScanRuntime::new());
 
     // 组装 Controller 并托管为 State，启动后台线程
     let controller = Arc::new(Controller::new(
         app_paths,
-        Mutex::new(oea_config),
+        oea_config,
         ocr,
         scenes,
-        stop,
-        running,
+        scan_runtime,
         scan_tx,
         foreground,
         app.handle().clone(),

--- a/src-tauri/src/scan_runtime.rs
+++ b/src-tauri/src/scan_runtime.rs
@@ -1,0 +1,265 @@
+//! 扫描档案库任务的运行时。
+//!
+//! [`ScanRuntime`] 只拥有一次扫描任务的生命周期状态。每次启动由
+//! [`ScanRunContext`] 带入本次运行所需的应用协作者，运行时不会把这些协作者
+//! 保留为状态。
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter};
+use tracing::{error, info, warn};
+
+use crate::{
+    app_paths::AppPaths,
+    config::OeaConfig,
+    connect::connect_to_game,
+    ocr::OcrEngine,
+    scene::SceneManager,
+    sound,
+    task::{TaskStopped, run_task},
+    tasks::archive_scan::{ArchiveScanTask, CorrectionIndex, ScanReporter},
+    windows_ops,
+};
+
+/// 推送给前端的应用状态。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppStatus {
+    /// 扫描档案库任务是否正在运行
+    pub running: bool,
+    /// 扫描档案库任务结束时的失败原因（仅失败时随结束状态推送一次；成功 / 被停止 / 查询状态时为 `None`）
+    #[serde(default)]
+    pub scan_error: Option<String>,
+}
+
+/// 一次扫描运行所需的应用协作者。
+///
+/// 由 [`crate::controller::Controller`] 在任务被接受后创建，并移交给唯一的扫描线程。
+pub(crate) struct ScanRunContext {
+    app_path: AppPaths,
+    oea_config: Arc<Mutex<OeaConfig>>,
+    ocr: Arc<Mutex<OcrEngine>>,
+    scenes: Arc<SceneManager>,
+    correction: Arc<CorrectionIndex>,
+    reporter: ScanReporter,
+    handle: AppHandle,
+}
+
+impl ScanRunContext {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        app_path: AppPaths,
+        oea_config: Arc<Mutex<OeaConfig>>,
+        ocr: Arc<Mutex<OcrEngine>>,
+        scenes: Arc<SceneManager>,
+        correction: Arc<CorrectionIndex>,
+        reporter: ScanReporter,
+        handle: AppHandle,
+    ) -> Self {
+        Self {
+            app_path,
+            oea_config,
+            ocr,
+            scenes,
+            correction,
+            reporter,
+            handle,
+        }
+    }
+}
+
+/// 扫描档案库任务的生命周期状态。
+pub(crate) struct ScanRuntime {
+    /// 停止请求标志：`true` 表示当前扫描应尽快停止。
+    ///
+    /// [`Self::stop`] 和 [`Self::request_stop_for_shutdown`] 写入 `true`；工作线程在
+    /// 成功连接游戏后通过 [`crate::session::Session::reset_stop`] 写回 `false`。
+    /// 一次扫描的 [`crate::session::Session`] 在每个游戏操作前读取。
+    stop: Arc<AtomicBool>,
+    /// 运行标志：`true` 表示一个扫描已获准启动，直至其工作线程到达终态。
+    ///
+    /// [`Self::claim_start`] 用 CAS 写入 `true`；状态查询、停止与切换操作读取；
+    /// 工作线程的 [`Self::finish`] 在成功、停止或失败后写回 `false`。
+    running: AtomicBool,
+}
+
+impl ScanRuntime {
+    pub(crate) fn new() -> Self {
+        Self {
+            stop: Arc::new(AtomicBool::new(false)),
+            running: AtomicBool::new(false),
+        }
+    }
+
+    /// 启动扫描档案库任务：CAS 占用运行标志 → 推送状态 → 后台线程执行。
+    pub(crate) fn start(self: &Arc<Self>, context_factory: impl FnOnce() -> ScanRunContext) {
+        if !self.claim_start() {
+            warn!("扫描档案库任务正在运行中，忽略重复的启动请求");
+            return;
+        }
+        info!("收到启动扫描档案库任务请求");
+        let context = context_factory();
+        self.emit_status(&context.handle, None);
+
+        let runtime = Arc::clone(self);
+        thread::Builder::new()
+            .name("oea-scan".to_string())
+            .spawn(move || runtime.run(context))
+            .expect("启动扫描档案库任务线程失败");
+    }
+
+    /// 请求停止扫描档案库任务。
+    pub(crate) fn stop(&self) {
+        if !self.running.load(Ordering::Relaxed) {
+            warn!("扫描档案库任务未在运行，忽略停止请求");
+            return;
+        }
+        self.request_stop_for_shutdown();
+        info!("收到停止请求，正在停止扫描档案库任务...");
+    }
+
+    /// 进程退出前请求停止，不改变原有的立即退出策略。
+    pub(crate) fn request_stop_for_shutdown(&self) {
+        self.stop.store(true, Ordering::Relaxed);
+    }
+
+    /// 读取当前扫描状态。
+    pub(crate) fn status(&self) -> AppStatus {
+        AppStatus {
+            running: self.running.load(Ordering::Relaxed),
+            scan_error: None,
+        }
+    }
+
+    fn claim_start(&self) -> bool {
+        self.running
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+    }
+
+    fn run(self: Arc<Self>, context: ScanRunContext) {
+        // 任务开始时才连接游戏（游戏未打开则报错并复位）
+        let mut session = match connect_to_game(
+            &context.ocr,
+            &context.app_path.templates_dir(),
+            Arc::clone(&self.stop),
+        ) {
+            Ok(session) => session,
+            Err(error) => {
+                error!("连接游戏失败: {error:#}");
+                self.play_scan_sound(&context, false);
+                self.finish(&context.handle, Some(format!("连接游戏失败: {error:#}")));
+                return;
+            }
+        };
+
+        // 扫描档案库任务需要点击游戏窗口，先确保窗口在前台（失败不阻断）
+        if let Err(error) = windows_ops::window::ensure_foreground_and_topmost(session.hwnd) {
+            warn!("无法将游戏窗口置于前台: {error:#}，继续尝试执行任务");
+        }
+
+        // 清除上一次可能残留的停止信号
+        session.reset_stop();
+
+        // 启动检查通过、任务真正开始执行前播放 enable 提示音
+        // （避免"启动后立即失败"时 enable/disable 两个音效同时播放）
+        self.play_scan_sound(&context, true);
+
+        // 执行扫描档案库任务（阻塞，期间任务内部轮询停止标志）
+        let task = ArchiveScanTask::new(context.reporter.clone(), Arc::clone(&context.correction));
+        let result = run_task(&task, &mut session, &context.scenes);
+
+        // 区分"被停止"与"出错"
+        match result {
+            Ok(()) => {
+                info!("========== 扫描档案库任务执行完毕 ==========");
+                self.play_scan_sound(&context, true);
+                self.finish(&context.handle, None);
+            }
+            Err(error) if error.downcast_ref::<TaskStopped>().is_some() => {
+                info!("扫描档案库任务已被用户停止");
+                self.play_scan_sound(&context, false);
+                self.finish(&context.handle, None);
+            }
+            Err(error) => {
+                error!("扫描档案库任务执行失败: {error:#}");
+                self.play_scan_sound(&context, false);
+                self.finish(
+                    &context.handle,
+                    Some(format!("扫描档案库任务执行失败: {error:#}")),
+                );
+            }
+        }
+    }
+
+    /// 播放扫描提示音（音量取配置；开始/自然完成播 enable，失败/被停止播 disable）。
+    fn play_scan_sound(&self, context: &ScanRunContext, enable: bool) {
+        let volume = context
+            .oea_config
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .sound_volume;
+        let name = if enable { "enable.wav" } else { "disable.wav" };
+        let path = context.app_path.resources_dir().join("sounds").join(name);
+        sound::play_wav(&path, volume);
+    }
+
+    /// 复位运行标志并推送"空闲"状态（携带本次任务的失败原因，无失败时为 `None`）。
+    fn finish(&self, handle: &AppHandle, scan_error: Option<String>) {
+        self.release_run();
+        self.emit_status(handle, scan_error);
+    }
+
+    fn release_run(&self) {
+        self.running.store(false, Ordering::Relaxed);
+    }
+
+    /// 向前端推送当前状态（running 标志 + 本次任务结束时的失败原因）。
+    fn emit_status(&self, handle: &AppHandle, scan_error: Option<String>) {
+        let status = AppStatus {
+            running: self.running.load(Ordering::Relaxed),
+            scan_error,
+        };
+        if let Err(error) = handle.emit("app-status", &status) {
+            error!("向前端推送状态失败: {error}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::Ordering;
+
+    use super::ScanRuntime;
+
+    #[test]
+    fn new_runtime_is_idle() {
+        assert!(!ScanRuntime::new().status().running);
+    }
+
+    #[test]
+    fn running_scan_rejects_a_second_claim_until_it_finishes() {
+        let runtime = ScanRuntime::new();
+
+        assert!(runtime.claim_start());
+        assert!(!runtime.claim_start());
+
+        runtime.release_run();
+        assert!(runtime.claim_start());
+    }
+
+    #[test]
+    fn stop_request_is_ignored_while_idle_and_recorded_while_running() {
+        let runtime = ScanRuntime::new();
+
+        runtime.stop();
+        assert!(!runtime.stop.load(Ordering::Relaxed));
+
+        assert!(runtime.claim_start());
+        runtime.stop();
+        assert!(runtime.stop.load(Ordering::Relaxed));
+    }
+}


### PR DESCRIPTION
> This message is generated by AI.

`Controller` 目前同时保存应用依赖、扫描状态，并负责扫描工作线程的生命周期。此 PR 将扫描任务专属的状态与执行路径收拢到 `ScanRuntime`，保留 `Controller` 作为 Tauri 命令、托盘和热键共用的应用门面。

## 结构变化

```mermaid
flowchart LR
  subgraph Before["改动前"]
    Command["Tauri 命令"] --> Controller["Controller"]
    Tray["托盘"] --> Controller
    Hotkey["热键"] --> Controller
    Controller --> State["running / stop"]
    Controller --> Worker["扫描工作线程"]
    Worker --> Task["Session + ArchiveScanTask"]
    Controller --> Events["状态 / 结果事件"]
  end
```

```mermaid
flowchart LR
  subgraph After["改动后"]
    Command["Tauri 命令"] --> Controller["Controller"]
    Tray["托盘"] --> Controller
    Hotkey["热键"] --> Controller

    Controller --> Context["构造每次扫描的运行上下文<br/>（OCR、消息管道）"]
    Controller --> Runtime["ScanRuntime"]
    Context --> Runtime["ScanRuntime"]
    Runtime --> State["running / stop"]
    Runtime --> Worker["扫描工作线程"]
    Worker --> Task["Session + ArchiveScanTask"]
    Runtime --> Events["状态事件"]
    Task --> Results["扫描结果事件"]
  end
```

`Controller` 仅在扫描请求被接受后创建运行上下文，并将 OCR、场景管理器、纠错索引、配置、结果上报器和 Tauri 句柄移交给该次扫描。前端命令与事件名称保持不变。

验证：

- `cargo fmt --all -- --check`
- `cargo xwin check --target x86_64-pc-windows-msvc --all-targets`
- `cargo xwin clippy --target x86_64-pc-windows-msvc --all-targets -- -D warnings`
- `cargo xwin build --target x86_64-pc-windows-msvc`
- 已完成针对规范与需求的审查

## Sourcery 摘要

将扫描任务运行时职责从 Controller 提取到 ScanRuntime，同时保留现有应用接口与前端行为。

增强功能：
- 将扫描任务的生命周期状态、停止控制、工作线程编排和状态事件转发集中到独立的 ScanRuntime 中。
- 精简 Controller，使其专注于应用层命令、托盘和热键编排，并为每次扫描创建独立运行上下文。
- 保持前端状态查询、事件和命令接口不变，同时增加 ScanRuntime 生命周期行为的单元测试。

测试：
- 为扫描运行时的初始状态、重复启动保护和停止请求行为添加单元测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将扫描任务运行时职责从 Controller 提取到 ScanRuntime，同时保留现有应用接口与前端行为。

Enhancements:
- 将扫描任务的生命周期状态、停止控制、工作线程编排和状态事件转发集中到独立的 ScanRuntime 中。
- 精简 Controller，使其专注于应用层命令、托盘和热键编排，并为每次扫描创建独立运行上下文。
- 保持前端状态查询、事件和命令接口不变，同时增加 ScanRuntime 生命周期行为的单元测试。

Tests:
- 为扫描运行时的初始状态、重复启动保护和停止请求行为添加单元测试。

</details>