### PR TITLE
fix(macOS): 修复开发外壳编译并收拢 Windows 原生接口

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -47,7 +47,6 @@ tracing = "0.1.44"
 tracing-appender = "0.2.5"
 tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.23", features = ["chrono"] }
-webview2-com = "0.38"
 zip = "7.2.0"
 
 
@@ -58,6 +57,7 @@ debug = false
 overflow-checks = false
 
 [target."cfg(windows)".dependencies]
+webview2-com = "0.38"
 windows = { version = "0.61", features = ["Foundation_Metadata", "Graphics_Capture", "Graphics_DirectX", "Graphics_DirectX_Direct3D11", "Security_Authorization_AppCapabilityAccess", "Win32_Devices_Display", "Win32_Foundation", "Win32_Graphics_Direct3D", "Win32_Graphics_Direct3D11", "Win32_Graphics_Dxgi", "Win32_Graphics_Dxgi_Common", "Win32_Graphics_Gdi", "Win32_Security", "Win32_Security_Cryptography", "Win32_Storage_Xps", "Win32_System_Registry", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WinRT_Direct3D11", "Win32_System_WinRT_Graphics_Capture", "Win32_UI_HiDpi", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
 
 [profile.release]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,7 +6,6 @@ pub mod connect;
 pub mod controller;
 pub mod crash;
 pub mod data;
-pub mod dpapi;
 pub mod logger;
 pub mod ocr;
 pub mod resolution;
@@ -191,7 +190,7 @@ fn setup_app(app: &mut tauri::App) -> Result<()> {
     let main_window_builder = configure_main_window(main_window_builder, &app_paths);
 
     let main_window = main_window_builder.build()?;
-    register_zoom_changed_listener(&main_window);
+    windows_ops::webview2::register_zoom_changed_listener(&main_window);
 
     // 扫描结果通道：任务线程产生 → 转发线程 emit 给前端
     let (scan_tx, scan_rx) = mpsc::channel();
@@ -240,44 +239,4 @@ fn setup_app(app: &mut tauri::App) -> Result<()> {
 
     info!("OEA 后端初始化完成");
     Ok(())
-}
-
-/// 注册 WebView2 原生缩放（`ZoomFactor`）变化监听。
-///
-/// 用户通过 `Ctrl+滚轮` / `Ctrl+加减` 缩放时，WebView2 内部会修改 `ZoomFactor` 并触发
-/// `ZoomFactorChanged` 事件。这里把新值 emit 给前端（`webview-zoom-changed`），
-/// 让设置页的缩放滑块与快捷键缩放保持同步。
-fn register_zoom_changed_listener(window: &tauri::WebviewWindow) {
-    use tauri::Emitter;
-    use webview2_com::{
-        Microsoft::Web::WebView2::Win32::ICoreWebView2Controller, ZoomFactorChangedEventHandler,
-    };
-    use windows::core::IUnknown;
-
-    let app_handle = window.app_handle().clone();
-
-    let result = window.with_webview(move |platform_webview| {
-        let controller = platform_webview.controller();
-
-        let handler = ZoomFactorChangedEventHandler::create(Box::new(
-            move |sender: Option<ICoreWebView2Controller>, _args: Option<IUnknown>| {
-                let Some(controller) = sender else {
-                    return Ok(());
-                };
-                let mut factor = 0.0f64;
-                unsafe { controller.ZoomFactor(&mut factor) }?;
-                let _ = app_handle.emit("webview-zoom-changed", factor);
-                Ok(())
-            },
-        ));
-
-        let mut token = 0i64;
-        if let Err(e) = unsafe { controller.add_ZoomFactorChanged(&handler, &mut token) } {
-            warn!("注册 ZoomFactorChanged 监听失败: {e}");
-        }
-    });
-
-    if let Err(e) = result {
-        warn!("获取 WebView2 controller 失败: {e:#}");
-    }
 }

--- a/src-tauri/src/tauri_commands.rs
+++ b/src-tauri/src/tauri_commands.rs
@@ -72,22 +72,7 @@ pub fn restart_as_admin(app_handle: tauri::AppHandle) -> Result<(), String> {
 /// 前端只把它当作内存镜像，不再额外持久化。
 #[tauri::command]
 pub fn get_webview_zoom(window: tauri::WebviewWindow) -> Result<f64, String> {
-    use std::sync::mpsc;
-
-    let (tx, rx) = mpsc::channel();
-    window
-        .with_webview(move |platform_webview| {
-            let controller = platform_webview.controller();
-            let mut factor = 0.0f64;
-            let zoom = unsafe { controller.ZoomFactor(&mut factor) }
-                .ok()
-                .map(|_| factor);
-            let _ = tx.send(zoom);
-        })
-        .map_err(|e| e.to_string())?;
-    rx.recv()
-        .map_err(|e| e.to_string())?
-        .ok_or_else(|| "读取 WebView2 缩放因子失败".to_string())
+    windows_ops::webview2::get_zoom(window).map_err(|e| e.to_string())
 }
 
 /// 在系统文件管理器中打开日志目录（不存在时先创建）。
@@ -134,7 +119,7 @@ pub fn save_oea_config(
 /// 用 DPAPI（当前用户作用域）加密 CDK，返回 Base64 密文。
 #[tauri::command]
 pub fn cdk_encrypt(cdk: String) -> Result<String, String> {
-    let encrypted = crate::dpapi::encrypt(cdk.trim().as_bytes()).map_err(|e| {
+    let encrypted = windows_ops::dpapi::encrypt(cdk.trim().as_bytes()).map_err(|e| {
         error!("加密 CDK 失败: {e}");
         e.to_string()
     })?;
@@ -148,7 +133,7 @@ pub fn cdk_decrypt(encrypted: String) -> Result<String, String> {
         error!("CDK 密文 Base64 解码失败: {e}");
         e.to_string()
     })?;
-    let plain = crate::dpapi::decrypt(&blob).map_err(|e| {
+    let plain = windows_ops::dpapi::decrypt(&blob).map_err(|e| {
         error!("解密 CDK 失败: {e}");
         e.to_string()
     })?;

--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -18,7 +18,9 @@ use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tauri::Emitter;
-use tracing::{info, warn};
+use tracing::info;
+#[cfg(target_os = "windows")]
+use tracing::warn;
 
 /// 下载进度事件（前端按 `session_id` 过滤旧任务的迟到事件）。
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -146,6 +148,7 @@ fn resolve_system_proxy_inner() -> Result<Option<String>, String> {
 /// - `host:port` → `http://host:port`
 /// - `http=host:port;https=host2:port` → 优先 `https=`，否则 `http=`
 /// - 仅含 `socks=` 或无法解析时返回 `None`（reqwest 未启用 socks 特性）
+#[cfg(any(target_os = "windows", test))]
 fn normalize_proxy_server(raw: &str) -> Option<String> {
     let raw = raw.trim();
     if raw.is_empty() {

--- a/src-tauri/src/windows_ops/details/dpapi.rs
+++ b/src-tauri/src/windows_ops/details/dpapi.rs
@@ -4,6 +4,7 @@
 //! 密文仅能在本机、当前 Windows 用户下解密，复制到其他机器或切换用户后均无法解密。
 //! 本模块只处理原始字节，Base64 编码交由调用方处理。
 
+use anyhow::Result;
 use windows::Win32::Foundation::{HLOCAL, LocalFree};
 use windows::Win32::Security::Cryptography::{
     CRYPT_INTEGER_BLOB, CRYPTPROTECT_UI_FORBIDDEN, CryptProtectData, CryptUnprotectData,
@@ -11,7 +12,7 @@ use windows::Win32::Security::Cryptography::{
 use windows::core::PCWSTR;
 
 /// 用 DPAPI（当前用户作用域）加密字节串，返回密文字节。
-pub fn encrypt(plain: &[u8]) -> windows::core::Result<Vec<u8>> {
+pub(in crate::windows_ops) fn encrypt(plain: &[u8]) -> Result<Vec<u8>> {
     let input = CRYPT_INTEGER_BLOB {
         cbData: plain.len() as u32,
         pbData: plain.as_ptr() as *mut u8,
@@ -36,7 +37,7 @@ pub fn encrypt(plain: &[u8]) -> windows::core::Result<Vec<u8>> {
 }
 
 /// 解密密文字节串，返回明文字节串。换机器或切换用户时返回 `Err`。
-pub fn decrypt(data: &[u8]) -> windows::core::Result<Vec<u8>> {
+pub(in crate::windows_ops) fn decrypt(data: &[u8]) -> Result<Vec<u8>> {
     let input = CRYPT_INTEGER_BLOB {
         cbData: data.len() as u32,
         pbData: data.as_ptr() as *mut u8,

--- a/src-tauri/src/windows_ops/details/mod.rs
+++ b/src-tauri/src/windows_ops/details/mod.rs
@@ -3,6 +3,7 @@
 pub(super) mod admin;
 pub(super) mod capture;
 pub(super) mod dialog;
+pub(super) mod dpapi;
 mod geometry;
 pub(super) mod hotkey;
 pub(super) mod input;

--- a/src-tauri/src/windows_ops/details/webview2/mod.rs
+++ b/src-tauri/src/windows_ops/details/webview2/mod.rs
@@ -10,5 +10,7 @@
 
 mod detection;
 mod install;
+mod zoom;
 
 pub(in crate::windows_ops) use install::ensure_installed;
+pub(in crate::windows_ops) use zoom::{get_zoom, register_zoom_changed_listener};

--- a/src-tauri/src/windows_ops/details/webview2/zoom.rs
+++ b/src-tauri/src/windows_ops/details/webview2/zoom.rs
@@ -1,0 +1,62 @@
+//! WebView2 原生缩放接口。
+
+use std::sync::mpsc;
+
+use anyhow::{Context, Result, anyhow};
+use tauri::{Emitter, Manager};
+use tracing::warn;
+use webview2_com::{
+    Microsoft::Web::WebView2::Win32::ICoreWebView2Controller, ZoomFactorChangedEventHandler,
+};
+use windows::core::IUnknown;
+
+/// 读取 WebView2 当前缩放因子。
+pub(in crate::windows_ops) fn get_zoom(window: tauri::WebviewWindow) -> Result<f64> {
+    let (tx, rx) = mpsc::channel();
+    window
+        .with_webview(move |platform_webview| {
+            let controller = platform_webview.controller();
+            let mut factor = 0.0f64;
+            let zoom = unsafe { controller.ZoomFactor(&mut factor) }
+                .ok()
+                .map(|_| factor);
+            let _ = tx.send(zoom);
+        })
+        .context("获取 WebView2 controller 失败")?;
+    rx.recv()
+        .context("接收 WebView2 缩放因子失败")?
+        .ok_or_else(|| anyhow!("读取 WebView2 缩放因子失败"))
+}
+
+/// 注册 WebView2 原生缩放（`ZoomFactor`）变化监听。
+///
+/// 用户通过 `Ctrl+滚轮` / `Ctrl+加减` 缩放时，WebView2 内部会修改 `ZoomFactor` 并触发
+/// `ZoomFactorChanged` 事件。这里把新值 emit 给前端（`webview-zoom-changed`），
+/// 让设置页的缩放滑块与快捷键缩放保持同步。
+pub(in crate::windows_ops) fn register_zoom_changed_listener(window: &tauri::WebviewWindow) {
+    let app_handle = window.app_handle().clone();
+
+    let result = window.with_webview(move |platform_webview| {
+        let controller = platform_webview.controller();
+        let handler = ZoomFactorChangedEventHandler::create(Box::new(
+            move |sender: Option<ICoreWebView2Controller>, _args: Option<IUnknown>| {
+                let Some(controller) = sender else {
+                    return Ok(());
+                };
+                let mut factor = 0.0f64;
+                unsafe { controller.ZoomFactor(&mut factor) }?;
+                let _ = app_handle.emit("webview-zoom-changed", factor);
+                Ok(())
+            },
+        ));
+
+        let mut token = 0i64;
+        if let Err(e) = unsafe { controller.add_ZoomFactorChanged(&handler, &mut token) } {
+            warn!("注册 ZoomFactorChanged 监听失败: {e}");
+        }
+    });
+
+    if let Err(e) = result {
+        warn!("获取 WebView2 controller 失败: {e:#}");
+    }
+}

--- a/src-tauri/src/windows_ops/dpapi.rs
+++ b/src-tauri/src/windows_ops/dpapi.rs
@@ -1,0 +1,30 @@
+//! Windows DPAPI 加解密接口。
+
+use anyhow::Result;
+
+#[cfg(target_os = "windows")]
+use super::details;
+
+/// 使用当前 Windows 用户的 DPAPI 加密字节串。
+#[cfg(target_os = "windows")]
+pub fn encrypt(plain: &[u8]) -> Result<Vec<u8>> {
+    details::dpapi::encrypt(plain)
+}
+
+/// macOS 开发外壳不提供 Windows DPAPI。
+#[cfg(target_os = "macos")]
+pub fn encrypt(_plain: &[u8]) -> Result<Vec<u8>> {
+    Err(super::unsupported("DPAPI encryption"))
+}
+
+/// 使用当前 Windows 用户的 DPAPI 解密字节串。
+#[cfg(target_os = "windows")]
+pub fn decrypt(data: &[u8]) -> Result<Vec<u8>> {
+    details::dpapi::decrypt(data)
+}
+
+/// macOS 开发外壳不提供 Windows DPAPI。
+#[cfg(target_os = "macos")]
+pub fn decrypt(_data: &[u8]) -> Result<Vec<u8>> {
+    Err(super::unsupported("DPAPI decryption"))
+}

--- a/src-tauri/src/windows_ops/mod.rs
+++ b/src-tauri/src/windows_ops/mod.rs
@@ -12,6 +12,7 @@ mod details;
 pub mod admin;
 pub mod capture;
 pub mod dialog;
+pub mod dpapi;
 pub mod hotkey;
 pub mod input;
 #[cfg(target_os = "windows")]

--- a/src-tauri/src/windows_ops/webview2.rs
+++ b/src-tauri/src/windows_ops/webview2.rs
@@ -20,3 +20,25 @@ pub fn ensure_installed(cache_dir: &Path) -> Result<bool> {
 pub fn ensure_installed(_cache_dir: &Path) -> Result<bool> {
     Ok(true)
 }
+
+/// 读取 WebView2 当前缩放因子。
+#[cfg(target_os = "windows")]
+pub fn get_zoom(window: tauri::WebviewWindow) -> Result<f64> {
+    details::webview2::get_zoom(window)
+}
+
+/// macOS 开发外壳不跟踪 WebView2 缩放，使用默认缩放因子。
+#[cfg(target_os = "macos")]
+pub fn get_zoom(_window: tauri::WebviewWindow) -> Result<f64> {
+    Ok(1.0)
+}
+
+/// 注册 WebView2 原生缩放变化监听。
+#[cfg(target_os = "windows")]
+pub fn register_zoom_changed_listener(window: &tauri::WebviewWindow) {
+    details::webview2::register_zoom_changed_listener(window);
+}
+
+/// WKWebView 不提供 WebView2 原生缩放事件。
+#[cfg(target_os = "macos")]
+pub fn register_zoom_changed_listener(_window: &tauri::WebviewWindow) {}


### PR DESCRIPTION
> This message is generated by AI.

## 背景

自动更新与 WebView2 缩放能力合入后，`webview2-com` 被放在了全平台依赖中。macOS 开发外壳因此也会编译它的 Windows COM 依赖链，并在 `windows-future` 与 `windows-core` 的组合处因缺少 `IMarshal` / `marshaler` 符号而失败。

单纯调整依赖版本只能绕开当前冲突，不能恢复平台边界。继续把 DPAPI 与 WebView2 COM 调用留在通用入口中，也会让下一次依赖调整重新破坏 macOS 编译。因此本 PR 将依赖和原生实现一起收回 `windows_ops` 所有权根。

## 变更

- 将 `webview2-com` 限定为 Windows 目标依赖，避免 macOS 解析和编译 Windows COM 依赖链。
- 将 DPAPI 实现迁入 `windows_ops::details`，通过不暴露 Windows 原生类型的公共接口供 Tauri 命令调用；macOS 开发外壳返回明确的不支持错误。
- 将 WebView2 缩放读取和事件监听迁入 `windows_ops::details::webview2`，保留原有 Tauri 命令与前端事件契约；macOS 使用默认缩放因子 `1.0`，监听为空操作。
- 修正系统代理代码中仅 Windows 使用的导入与辅助函数的条件编译范围，使 macOS Clippy 检查无告警通过。

## 验证

- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo xwin check --target x86_64-pc-windows-msvc --all-targets`
- `cargo xwin clippy --target x86_64-pc-windows-msvc --all-targets -- -D warnings`
- `cargo xwin build --target x86_64-pc-windows-msvc`

## Sourcery 摘要

通过为原生 DPAPI 和 WebView2 功能强制设置 Windows 边界，恢复跨平台开发构建。

错误修复：
- 通过阻止在非 Windows 目标上构建 Windows WebView2 COM 依赖，恢复 macOS 开发 shell 的编译。
- 为 macOS 开发 shell 中仅支持 Windows 的 DPAPI 操作提供明确的不支持行为。

增强功能：
- 将 DPAPI 和 WebView2 缩放功能统一到由平台负责的 windows_ops 接口下，同时保留现有的 Tauri 命令和前端事件。
- 通过在 macOS 上返回默认缩放因子、在 Windows 上保留原生缩放跟踪，使 WebView2 缩放行为兼容各平台。
- 修正仅适用于 Windows 的代理导入和辅助函数，使 macOS Clippy 检查能够顺利通过。

构建：
- 将 webview2-com 限制为 Windows 目标依赖项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore cross-platform development builds by enforcing Windows boundaries for native DPAPI and WebView2 functionality.

Bug Fixes:
- Restore macOS development-shell compilation by preventing Windows WebView2 COM dependencies from being built on non-Windows targets.
- Provide explicit unsupported behavior for Windows-only DPAPI operations in the macOS development shell.

Enhancements:
- Consolidate DPAPI and WebView2 zoom functionality under the platform-owned windows_ops interfaces while preserving existing Tauri commands and frontend events.
- Keep WebView2 zoom behavior platform-compatible by returning a default factor on macOS and retaining native zoom tracking on Windows.
- Correct Windows-only proxy imports and helpers so macOS Clippy checks pass cleanly.

Build:
- Restrict webview2-com to Windows target dependencies.

</details>