### PR TITLE
docs: 收拢 Nuxt UI 前端规范

### DIFF
--- a/docs/rule-frontend.md
+++ b/docs/rule-frontend.md
@@ -13,10 +13,18 @@
 - 本项目启用 TypeScript：所有函数参数与返回值都要有类型注解（返回 `void` 的除外）；
 - 拒绝写 `anotherFunction(args)` 的简单包装函数。
 
-## Vue 组件
+## Vue 与 Nuxt UI
 
-- 需要编写组件时遵循 `nuxt-ui-expert` 规范；
+本项目使用 Vue 和 Vite，并将 Nuxt UI 作为 Vue 组件库使用。沿用现有 Vue/Vite 项目约定实现界面。
+
+- 对按钮、输入框等交互控件，在 Nuxt UI 提供等价组件时使用该组件；布局和文档结构使用合适的语义化 HTML；
+- 图标使用 Lucide 图标集提供的 `i-lucide-*` 图标；
+- 用 Nuxt UI 组件的 props 表达组件变体和状态，例如 `variant="subtle"`；用 Tailwind CSS 处理布局，以及组件 API 无法表达的样式；
+- 用 Nuxt UI 语义色统一明暗主题，例如 `text-toned`、`text-primary`、`bg-muted` 和 `bg-accented`；仅在语义色无法表达固定颜色等实际需求时使用 Tailwind 调色板或自定义颜色；
+- 无法确定组件是否存在，或不确定其 props、slots、图标语法、语义色和无障碍行为时，查阅与当前 `@nuxt/ui` 版本匹配的[官方文档](https://ui.nuxt.com/llms.txt)；
 - 属性排序等可自动修复的问题，运行 `pnpm lint:fix` 即可。
+
+完成界面修改前，逐一检查本次改动的交互控件、图标、组件样式和颜色是否遵循上述规则，并在最终说明中列出例外及原因。
 
 ## 自动修复
 


### PR DESCRIPTION
> This message is generated by AI.

## 背景

此前的 #5 同时修改了旧版 `AGENTS.md`，并通过新增 `nuxt-ui-expert` 技能提出 Nuxt UI 的组件、图标和颜色约定。此后，仓库已将前后端规范从 `AGENTS.md` 拆分到专题文档；继续沿用原 PR 的结构会让已经过时的入口调整和仍然有效的界面约定混在一起。

当前 `docs/rule-frontend.md` 仍要求前端组件遵循 `nuxt-ui-expert`，但该技能并未进入主分支，导致这条指引没有可到达的正文。这些约定篇幅较短，且所有前端修改都会经由 `AGENTS.md` 读取前端规范。为了承接 #5 中仍然适用的部分，并让规则只有一个维护入口，本 PR 将相关内容直接收进 `docs/rule-frontend.md`。

## 方案

- 明确本项目在 Vue/Vite 应用中将 Nuxt UI 作为组件库使用；
- 约定交互控件优先使用等价的 Nuxt UI 组件，同时为布局和文档结构保留语义化 HTML；
- 收拢 Lucide 图标、组件 props、Tailwind CSS 和语义色的使用边界；
- 在组件 API 或无障碍行为不明确时，要求查阅与当前依赖版本匹配的官方文档；
- 增加完成前的逐项检查，要求说明未遵循规则的例外及原因。

## 验证

- `pnpm exec prettier --check docs/rule-frontend.md`
- `git diff --check`

## Sourcery 总结

将 Nuxt UI 前端开发约定收拢至单一规范文档并补充完成前检查要求。

Bug Fixes:
- 将 Nuxt UI 前端规范直接纳入专题文档，移除对不可达 `nuxt-ui-expert` 技能的依赖。

Enhancements:
- 统一 Vue/Vite 项目中的 Nuxt UI 组件、Lucide 图标、组件 props、Tailwind CSS、语义色及官方文档查阅约定。
- 增加界面修改完成前的规范检查，并要求说明未遵循规则的例外原因。

Documentation:
- 完善前端规范文档，明确 Nuxt UI 组件使用、语义化 HTML 和无障碍行为等实践。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 Nuxt UI 前端开发约定收拢至单一规范文档并补充完成前检查要求。

Bug Fixes:
- 将 Nuxt UI 前端规范直接纳入专题文档，移除对不可达 `nuxt-ui-expert` 技能的依赖。

Enhancements:
- 统一 Vue/Vite 项目中的 Nuxt UI 组件、Lucide 图标、组件 props、Tailwind CSS、语义色及官方文档查阅约定。
- 增加界面修改完成前的规范检查，并要求说明未遵循规则的例外原因。

Documentation:
- 完善前端规范文档，明确 Nuxt UI 组件使用、语义化 HTML 和无障碍行为等实践。

</details>