### PR TITLE
feat: publish OEA releases to Cloudflare R2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 # 发版自动化 workflow
 #
-# 触发方式：推送 `v*` tag（如 `v0.1.0`）后，自动构建绿色便携 zip，并发布到 GitHub Releases（自动生成 changelog）。
+# 触发方式：推送 `v*` tag（如 `v0.1.0`）后，一次构建，同时分发到 GitHub Release、OEM Cloudflare R2 与 MirrorChyan。
 #
 # 要求：tag 必须与 `src-tauri/tauri.conf.json` 中的 `version` 一致（例如 version=0.1.0 时打 v0.1.0），
 #       下方「校验版本号与 tag 一致」步骤会在构建前校验，不一致直接失败。
@@ -16,34 +16,56 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      operation:
+        description: R2 操作；publish 会从 tag 重建并上传，promote 只切换已有版本
+        required: true
+        default: publish
+        type: choice
+        options:
+          - publish
+          - promote
+      tag:
+        description: 规范版本 tag，例如 v0.1.2
+        required: true
+        type: string
 
 permissions:
-  contents: write
-  actions: write
-
-concurrency:
-  group: release-${{ github.ref }}
-  cancel-in-progress: false
+  contents: read
 
 jobs:
-  build-and-release:
-    name: Build and release
+  build:
+    name: Build portable package
+    if: github.event_name == 'push' || inputs.operation == 'publish'
     runs-on: windows-latest
+    outputs:
+      tag: ${{ steps.release.outputs.tag }}
+      version: ${{ steps.release.outputs.version }}
+      artifact_name: ${{ steps.release.outputs.artifact_name }}
     steps:
-      - name: Checkout
+      - name: Checkout release tag
         uses: actions/checkout@v7
         with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
           submodules: recursive
 
-      - name: 校验版本号与 tag 一致
+      - name: Validate release tag and version
+        id: release
         shell: pwsh
         run: |
-          $tag = "${{ github.ref_name }}" -replace '^v', ''
-          $config = Get-Content -Raw src-tauri/tauri.conf.json | ConvertFrom-Json
-          if ($config.version -ne $tag) {
-            throw "tag ${{ github.ref_name }} 与 tauri.conf.json 版本 $($config.version) 不一致，请先同步版本号"
+          $tag = if ('${{ github.event_name }}' -eq 'workflow_dispatch') { '${{ inputs.tag }}' } else { '${{ github.ref_name }}' }
+          if ($tag -notmatch '^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$') {
+            throw "无效 release tag: $tag"
           }
-          Write-Host "构建版本: $($config.version)"
+          $version = $tag -replace '^v', ''
+          $config = Get-Content -Raw src-tauri/tauri.conf.json | ConvertFrom-Json
+          if ($config.version -ne $version) {
+            throw "tag $tag 与 tauri.conf.json 版本 $($config.version) 不一致"
+          }
+          "tag=$tag" >> $env:GITHUB_OUTPUT
+          "version=$version" >> $env:GITHUB_OUTPUT
+          "artifact_name=oea-release-$tag" >> $env:GITHUB_OUTPUT
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
@@ -62,25 +84,145 @@ jobs:
         with:
           workspaces: 'src-tauri -> target'
 
-      - name: Install frontend dependencies
-        run: pnpm install
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Build and package
         run: pnpm package
 
+      - name: Generate SHA-256 sidecar
+        shell: pwsh
+        run: |
+          $packages = @(Get-ChildItem releases -File -Filter '*.zip')
+          if ($packages.Count -ne 1) {
+            throw "预期正好一个 zip，实际为 $($packages.Count)"
+          }
+          $package = $packages[0]
+          $hash = (Get-FileHash -Algorithm SHA256 $package.FullName).Hash.ToLowerInvariant()
+          $sidecar = "$($package.FullName).sha256"
+          [IO.File]::WriteAllText($sidecar, "$hash  $($package.Name)`n", [Text.UTF8Encoding]::new($false))
+
+      - name: Upload shared release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.release.outputs.artifact_name }}
+          path: |
+            releases/*.zip
+            releases/*.zip.sha256
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
+  github-release:
+    name: Publish GitHub Release
+    if: github.event_name == 'push'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download shared release artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: ${{ needs.build.outputs.artifact_name }}
+          path: release-artifact
+
       - name: Create release
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ github.ref_name }}
-          name: ${{ github.ref_name }}
-          files: releases/*.zip
+          tag_name: ${{ needs.build.outputs.tag }}
+          name: ${{ needs.build.outputs.tag }}
+          files: |
+            release-artifact/*.zip
+            release-artifact/*.zip.sha256
           fail_on_unmatched_files: true
           generate_release_notes: true
 
-      - name: Trigger MirrorChyanUploading
+  r2-release:
+    name: Publish immutable package to R2
+    needs: build
+    runs-on: ubuntu-latest
+    environment: r2-production
+    concurrency:
+      group: oea-r2-stable-release
+      cancel-in-progress: false
+    steps:
+      - name: Checkout publishing scripts
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.build.outputs.tag }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download shared release artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: ${{ needs.build.outputs.artifact_name }}
+          path: release-artifact
+
+      - name: Upload package and advance stable
+        run: pnpm run r2:publish -- --tag "${{ needs.build.outputs.tag }}" --artifact-dir release-artifact
+        env:
+          R2_ACCOUNT_ID: ${{ vars.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+  r2-promote:
+    name: Promote existing R2 package
+    if: github.event_name == 'workflow_dispatch' && inputs.operation == 'promote'
+    runs-on: ubuntu-latest
+    environment: r2-production
+    concurrency:
+      group: oea-r2-stable-release
+      cancel-in-progress: false
+    steps:
+      - name: Checkout publishing scripts
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.tag }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Promote verified existing package
+        run: pnpm run r2:promote -- --tag "${{ inputs.tag }}"
+        env:
+          R2_ACCOUNT_ID: ${{ vars.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+  mirrorchyan:
+    name: Trigger MirrorChyan workflows
+    if: github.event_name == 'push' && needs.github-release.result == 'success'
+    needs: github-release
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Trigger MirrorChyan uploading and release notes
         shell: bash
         run: |
-          gh workflow run --repo $GITHUB_REPOSITORY mirrorchyan_release.yml -f tag=${{ github.ref_name }}
-          gh workflow run --repo $GITHUB_REPOSITORY mirrorchyan_release_note.yml -f tag=${{ github.ref_name }}
+          gh workflow run --repo "$GITHUB_REPOSITORY" mirrorchyan_release.yml -f tag="${{ github.ref_name }}"
+          gh workflow run --repo "$GITHUB_REPOSITORY" mirrorchyan_release_note.yml -f tag="${{ github.ref_name }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,7 +212,7 @@ jobs:
 
   mirrorchyan:
     name: Trigger MirrorChyan workflows
-    if: github.event_name == 'push' && needs.github-release.result == 'success'
+    if: github.event_name == 'push' && needs['github-release'].result == 'success'
     needs: github-release
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,9 @@ jobs:
     name: Build portable package
     if: github.event_name == 'push' || inputs.operation == 'publish'
     runs-on: windows-latest
+    permissions:
+      contents: read
+      actions: write
     outputs:
       tag: ${{ steps.release.outputs.tag }}
       version: ${{ steps.release.outputs.version }}
@@ -87,6 +90,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Download OCR models
+        run: pnpm download:models
+
       - name: Build and package
         run: pnpm package
 
@@ -120,6 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: read
     steps:
       - name: Download shared release artifact
         uses: actions/download-artifact@v5
@@ -142,6 +149,9 @@ jobs:
     name: Publish immutable package to R2
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     environment: r2-production
     concurrency:
       group: oea-r2-stable-release
@@ -150,7 +160,9 @@ jobs:
       - name: Checkout publishing scripts
         uses: actions/checkout@v7
         with:
-          ref: ${{ needs.build.outputs.tag }}
+          # 手动导入旧 tag 时，发布脚本可能尚未存在于该 tag；使用触发
+          # workflow 的分支/提交，构建产物仍来自 needs.build 指定的 tag。
+          ref: ${{ github.sha }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
@@ -181,6 +193,9 @@ jobs:
     name: Promote existing R2 package
     if: github.event_name == 'workflow_dispatch' && inputs.operation == 'promote'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     environment: r2-production
     concurrency:
       group: oea-r2-stable-release
@@ -189,7 +204,7 @@ jobs:
       - name: Checkout publishing scripts
         uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.tag }}
+          ref: ${{ github.sha }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6

--- a/docs/r2-release.md
+++ b/docs/r2-release.md
@@ -1,0 +1,58 @@
+# R2 发布基础设施首次配置
+
+## 对外端点
+
+- OEA 稳定入口：`https://oea.oem.re/` 与 `https://oea.oem.re/latest`。Worker 从 `channels/oea/stable.json` 读取清单并返回不缓存的 `302`。
+- OEA 版本化下载：`https://package.oem.re/releases/oea/<tag>/OEA-windows-x86_64-<tag>.zip`，例如 `https://package.oem.re/releases/oea/v0.1.3/OEA-windows-x86_64-v0.1.3.zip`。
+- R2 对象 key 与 CDN 路径一一对应；未来应用使用 `releases/<app-id>/<tag>/...` 和 `channels/<app-id>/stable.json`，互不覆盖。
+
+本项目的 release workflow 只使用 `r2-production` Environment 中的三项配置：
+
+- Variable `R2_ACCOUNT_ID`：Cloudflare account ID；
+- Secret `R2_ACCESS_KEY_ID`；
+- Secret `R2_SECRET_ACCESS_KEY`。
+
+后两项必须来自 Cloudflare R2 API Token。创建 token 时选择 **Object Read & Write**，并且只勾选 `opendfieldmap-package` bucket；不要使用 Admin Read & Write，也不要把 token 放入仓库变量、日志或本地提交。
+
+### 生成 R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY
+
+在 Cloudflare Dashboard 中进入 **R2 → Overview → Manage R2 API Tokens → Create API token**：
+
+1. 选择仅用于 R2 S3 API 的 token，权限设为 **Object Read & Write**。
+2. 将资源范围限制为本账号的 `opendfieldmap-package` bucket，不授予 bucket 管理、Zone、Workers 或其他 bucket 权限。
+3. 创建后立即复制 **Access Key ID** 和 **Secret Access Key**；Secret 只显示一次，丢失后只能撤销并重新创建。
+4. 在 GitHub 仓库 **Settings → Environments → r2-production** 中保存：
+   - Secret `R2_ACCESS_KEY_ID` = Access Key ID；
+   - Secret `R2_SECRET_ACCESS_KEY` = Secret Access Key；
+   - Variable `R2_ACCOUNT_ID` = Cloudflare 账号 ID（不是 Zone ID）。
+
+发布脚本使用 S3 endpoint `https://<R2_ACCOUNT_ID>.r2.cloudflarestorage.com`、region `auto`，bucket 名称在代码中固定为 `opendfieldmap-package`，因此不会因环境变量误配置而写入其他 bucket。建议给 Environment 配置 required reviewer，并每 90 天轮换密钥；轮换时先添加并验证新密钥，再撤销旧密钥。
+
+## Cloudflare 配置
+
+1. 在同一 Cloudflare account 中确认 R2 bucket `opendfieldmap-package` 已存在，并连接 Custom Domain `package.oem.re`。`r2.dev` 保持关闭，最低 TLS 建议为 1.2。
+2. 在 Atlos 的 `talos/oem-relink` 目录部署 Worker。`wrangler.toml` 中的 `OEA_PACKAGES` binding 必须指向上述 bucket。
+3. `oem.re` zone 当前存在外部管理的 `oem.re/*`、`beta.oem.re/*`、`blog.oem.re/*`、`oea.oem.re/*` routes；不要重新添加 `*.oem.re/*` wildcard，否则会拦截 `package.oem.re` 的 R2 Custom Domain。
+4. 为 `package.oem.re/releases/oea/*` 创建 Cache Rule：启用 Cache Everything，Edge TTL 和 Browser TTL 均为一年；不要匹配 `channels/oea/stable.json`。版本对象本身也带有 `public, max-age=31536000, immutable`。未来应用沿用 `releases/<app-id>/...` 与 `channels/<app-id>/stable.json` 命名空间。
+5. 为 `oem.re` zone 启用 Smart Tiered Cache。R2 Custom Domain 必须走 proxied Cloudflare DNS；不要为生产下载 CNAME 到 `r2.dev`。
+
+## GitHub 配置
+
+在仓库 **Settings → Environments → r2-production** 中添加上述变量和 secrets。建议启用 required reviewers，并把 Environment 的部署分支/Tag policy 限制到受保护的 `v*` 发布 tag 和受保护主分支的手动运行。
+
+推送版本 tag 后，`Build and release` 会构建一次 zip，再由独立 job 发布到 GitHub Release、R2 和 MirrorChyan。首次导入既有版本时手动运行：
+
+- `operation=publish`、`tag=v0.1.2`：重建并上传版本对象，然后推进 stable；
+- `operation=promote`、`tag=v0.1.2`：只验证并切换已有 R2 对象，用于回滚。
+
+OEA 版本对象位于 `releases/oea/<tag>/`，稳定指针是 `channels/oea/stable.json`。普通发布不会覆盖对象或倒退 stable；回滚必须通过受保护的 `promote` 手动运行。其他应用应使用自己的 `<app-id>` 命名空间，避免对象和 stable 指针冲突。
+
+## 验收命令
+
+```bash
+curl -I https://oea.oem.re/
+curl -I https://oea.oem.re/latest
+curl -I https://package.oem.re/releases/oea/v0.1.2/OEA-windows-x86_64-v0.1.2.zip
+```
+
+稳定入口应返回 `302`、`Cache-Control: no-store`，并将 Location 指向 `package.oem.re` 的版本化 URL；版本 zip 应返回 `Content-Type: application/zip`、长期 immutable 缓存头，并在新版本发布后保持旧 URL 可用。

--- a/docs/r2-release.md
+++ b/docs/r2-release.md
@@ -45,7 +45,7 @@
 - `operation=publish`、`tag=v0.1.2`：重建并上传版本对象，然后推进 stable；
 - `operation=promote`、`tag=v0.1.2`：只验证并切换已有 R2 对象，用于回滚。
 
-OEA 版本对象位于 `releases/oea/<tag>/`，稳定指针是 `channels/oea/stable.json`。普通发布不会覆盖对象或倒退 stable；回滚必须通过受保护的 `promote` 手动运行。其他应用应使用自己的 `<app-id>` 命名空间，避免对象和 stable 指针冲突。
+OEA 版本对象位于 `releases/oea/<tag>/`，稳定指针是 `channels/oea/stable.json`。普通发布不会覆盖对象或倒退 stable；回滚必须通过受保护的 `promote` 手动运行。其他应用应使用自己的 `<app-id>` 命名空间，避免对象和 stable 指针冲突。即使对象已存在且 metadata、大小一致，发布和 promote 仍会重新读取对象计算 SHA-256，防止内容被替换后错误进入 stable。
 
 ## 验收命令
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -32,7 +32,7 @@ tauri build --no-bundle && jiti scripts/package.ts
 
 ## 发版流程
 
-> **自动化发版**：推送 `v*` tag（如 `v0.1.0`）后，release workflow（`.github/workflows/release.yml`）会自动构建 zip 并发布到 GitHub Releases（自动生成 changelog）。
+> **自动化发版**：推送 `v*` tag（如 `v0.1.0`）后，release workflow（`.github/workflows/release.yml`）只构建一次 zip，并独立发布到 GitHub Releases、Cloudflare R2 与 MirrorChyan。R2 的稳定下载入口为 `https://oea.oem.re/` 和 `https://oea.oem.re/latest`。
 > **tag 必须与 `src-tauri/tauri.conf.json` 中的 `version` 一致**（例如版本为 `0.1.0` 时打 `v0.1.0`）。workflow 会在构建前校验二者一致，不一致则构建失败。
 
 1. **更新版本号**（唯一来源 `src-tauri/tauri.conf.json`；前端编译期注入、打包命名与 release tag 校验均以此文件为准，无需维护 `package.json` / `Cargo.toml` 的版本号）：
@@ -62,6 +62,16 @@ tauri build --no-bundle && jiti scripts/package.ts
    git push origin main --tags
    ```
 
-   推送后 release workflow 会自动完成构建与 GitHub Release 发布（上传 zip、自动生成 changelog）。
+   推送后 release workflow 会自动完成构建、生成 SHA-256 sidecar，并独立执行 GitHub Release、R2 与 MirrorChyan 发布。R2 失败会使对应 job 失败，但不会撤销或阻塞其他分发渠道。
 
 7. **（可选）手动发布**：若 workflow 未自动创建 Release，可在 [Releases](https://github.com/Logical-Byte/open-endfield-assistant/releases) 页面以 `v0.1.0` 手动创建 release，上传 `releases/OEA-windows-x86_64-v0.1.0.zip`，填写变更说明。
+
+## R2 发布与回滚
+
+- bucket 固定为 `opendfieldmap-package`，OEA 版本对象位于 `releases/oea/<tag>/`，永不覆盖或自动过期；其他应用使用各自的 `releases/<app-id>/` 命名空间。
+- `channels/oea/stable.json` 是 OEA 稳定通道的唯一指针；普通发布只允许指针保持不变或升级，较旧 tag 的乱序任务只能补充归档，不能降低 stable。
+- 安装包达到 `512 MiB` 时 R2 发布会失败并保留旧 stable，避免产生无法被当前 Cloudflare 套餐缓存的下载链接。
+- 在 GitHub Actions 手动运行 **Build and release**：
+  - `operation=publish`：从指定 tag 重建、校验并发布到 R2，不重复创建 GitHub Release。
+  - `operation=promote`：校验 R2 中已有版本及其 checksum 后，仅切换 stable，用于受保护的回滚。
+- GitHub Environment `r2-production` 需要变量 `R2_ACCOUNT_ID`，以及 secrets `R2_ACCESS_KEY_ID`、`R2_SECRET_ACCESS_KEY`。凭据只能授予 `opendfieldmap-package` 的 R2 Object Read & Write 权限。

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
     "makedata": "jiti scripts/makeAllData.ts",
     "download:models": "jiti scripts/downloadModels.ts",
     "package": "tauri build --no-bundle && jiti scripts/package.ts",
-    "bump:version": "jiti scripts/bumpVersion.ts"
+    "bump:version": "jiti scripts/bumpVersion.ts",
+    "r2:publish": "jiti scripts/publishR2.ts publish",
+    "r2:promote": "jiti scripts/publishR2.ts promote",
+    "test:r2-release": "vitest run scripts/publishR2Core.test.ts"
   },
   "dependencies": {
     "@nuxt/ui": "^4.10.0",
@@ -37,6 +40,8 @@
     "vue-router": "^5.2.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-s3": "^3.1121.0",
+    "@aws-sdk/lib-storage": "^3.1121.0",
     "@octokit/types": "^17.0.0",
     "@tauri-apps/cli": "^2.11.4",
     "@types/node": "^26.1.2",
@@ -55,6 +60,7 @@
     "typescript-eslint": "^8.65.0",
     "vite": "^7.3.6",
     "vite-plugin-html": "^3.2.2",
+    "vitest": "^4.1.11",
     "vue-tsc": "^3.3.9",
     "yazl": "^3.3.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,12 @@ importers:
         specifier: ^5.2.0
         version: 5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.1)(rollup@4.62.4)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
     devDependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.1121.0
+        version: 3.1121.0
+      '@aws-sdk/lib-storage':
+        specifier: ^3.1121.0
+        version: 3.1121.0(@aws-sdk/client-s3@3.1121.0)
       '@octokit/types':
         specifier: ^17.0.0
         version: 17.0.0
@@ -108,6 +114,9 @@ importers:
       vite-plugin-html:
         specifier: ^3.2.2
         version: 3.2.2(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+      vitest:
+        specifier: ^4.1.11
+        version: 4.1.11(@types/node@26.1.2)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
       vue-tsc:
         specifier: ^3.3.9
         version: 3.3.9(typescript@6.0.3)
@@ -123,6 +132,84 @@ packages:
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
+  '@aws-sdk/checksums@3.1000.29':
+    resolution: {integrity: sha512-Dtu0gr4dnATZAPwEYbpCsG+MpLM7OAliy2gTepEFQwl1vZ6DL3QMH2FveMa3HLvPsOdhJsPRB3KtxVhph9T75A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-s3@3.1121.0':
+    resolution: {integrity: sha512-hBnoqaVBeWdkgXcJElMXA2yUZWkBCBntu2qmN+tfqmzC+j4LzJC3ox8qIgS2WdMS1cb8UwyBogUVrkRXybNm0A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.977.9':
+    resolution: {integrity: sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.70':
+    resolution: {integrity: sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.72':
+    resolution: {integrity: sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.15':
+    resolution: {integrity: sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.77':
+    resolution: {integrity: sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.81':
+    resolution: {integrity: sha512-Rml+WitoFvXmv6JZ18U/xGdGDGGvB/mOin0ya0lTnTrdC0Z1lrVxTYh7iNklZBcvcRMrs4DoEf6xy1KWyrLQQw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.70':
+    resolution: {integrity: sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.973.14':
+    resolution: {integrity: sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.76':
+    resolution: {integrity: sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/lib-storage@3.1121.0':
+    resolution: {integrity: sha512-sx86QqM0/HjKNCS5eQGcaP9Q8GKg3FtCExO/6FfGyw00JNUsFJPmEKNCJIkWY7OmKS9jIOuJe/DtAgfr/+G/bQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@aws-sdk/client-s3': ^3.1121.0
+
+  '@aws-sdk/middleware-sdk-s3@3.972.75':
+    resolution: {integrity: sha512-wMIsNumRVKaNMKhvU/s9VrdEwE8S6gSzXp4RygFG5BEMnGkkXf8cjh8zf7cKJBpUDpqTWqwbz5isEgp9rH6Lng==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.44':
+    resolution: {integrity: sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.46':
+    resolution: {integrity: sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1116.0':
+    resolution: {integrity: sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.5':
+    resolution: {integrity: sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.40':
+    resolution: {integrity: sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/generator@8.0.0':
     resolution: {integrity: sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==}
@@ -837,6 +924,30 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@smithy/core@3.33.3':
+    resolution: {integrity: sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.5.2':
+    resolution: {integrity: sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.7.2':
+    resolution: {integrity: sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.11.3':
+    resolution: {integrity: sha512-2jY1tSpERfPfWqyBV2pH+iGFaghVsIJszJNsT7hxtQYhVJpWDyc0LqOWI+nXOxOAHaEfZ4PXXtp1wW1TGpHhkA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.7.3':
+    resolution: {integrity: sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.17.2':
+    resolution: {integrity: sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==}
+    engines: {node: '>=18.0.0'}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -1268,6 +1379,12 @@ packages:
       y-protocols: ^1.0.1
       yjs: ^13.5.38
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
 
@@ -1368,6 +1485,35 @@ packages:
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       vue: ^3.2.25
+
+  '@vitest/expect@4.1.11':
+    resolution: {integrity: sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==}
+
+  '@vitest/mocker@4.1.11':
+    resolution: {integrity: sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.11':
+    resolution: {integrity: sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==}
+
+  '@vitest/runner@4.1.11':
+    resolution: {integrity: sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==}
+
+  '@vitest/snapshot@4.1.11':
+    resolution: {integrity: sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==}
+
+  '@vitest/spy@4.1.11':
+    resolution: {integrity: sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==}
+
+  '@vitest/utils@4.1.11':
+    resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
 
   '@volar/language-core@2.4.28':
     resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
@@ -1524,6 +1670,10 @@ packages:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-kit@2.2.0:
     resolution: {integrity: sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==}
     engines: {node: '>=20.19.0'}
@@ -1542,11 +1692,17 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   birpc@2.9.0:
     resolution: {integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==}
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   brace-expansion@2.1.4:
     resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
@@ -1566,6 +1722,9 @@ packages:
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
+  buffer@5.6.0:
+    resolution: {integrity: sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==}
+
   c12@3.3.4:
     resolution: {integrity: sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==}
     peerDependencies:
@@ -1576,6 +1735,10 @@ packages:
 
   camel-case@4.1.2:
     resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
@@ -1617,6 +1780,9 @@ packages:
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie-es@1.2.3:
     resolution: {integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==}
@@ -1763,6 +1929,9 @@ packages:
   errx@0.1.2:
     resolution: {integrity: sha512-chfpPHmCerdo/rXr/nNvPZRkV4WwDRwzwnsJ0Uzz3tVi8Z41tDctRjduYy1138ii77AFlts1qvWtX3g/Acg91Q==}
 
+  es-module-lexer@2.3.2:
+    resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
+
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
@@ -1863,9 +2032,17 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+
   execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   exsolve@1.1.1:
     resolution: {integrity: sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==}
@@ -2011,6 +2188,9 @@ packages:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -2025,6 +2205,9 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
@@ -2615,6 +2798,10 @@ packages:
     resolution: {integrity: sha512-PNaGjoCnw9DBA2Kl8D+8po957z778q/HOPuY2u3Bkw/JO3eC8MDx7jn/PgMtSgpcBbs+6UOjDbwReGpXmRvs0g==}
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
@@ -2647,6 +2834,9 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
   scule@1.3.0:
     resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
 
@@ -2667,6 +2857,9 @@ packages:
     resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -2686,8 +2879,17 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
+  stream-browserify@3.0.0:
+    resolution: {integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   strip-final-newline@3.0.0:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
@@ -2730,6 +2932,9 @@ packages:
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@1.3.0:
     resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
     engines: {node: '>=18'}
@@ -2737,6 +2942,10 @@ packages:
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -3004,6 +3213,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.11:
+    resolution: {integrity: sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.11
+      '@vitest/browser-preview': 4.1.11
+      '@vitest/browser-webdriverio': 4.1.11
+      '@vitest/coverage-istanbul': 4.1.11
+      '@vitest/coverage-v8': 4.1.11
+      '@vitest/ui': 4.1.11
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
@@ -3079,6 +3329,11 @@ packages:
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
     hasBin: true
 
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
@@ -3117,6 +3372,181 @@ snapshots:
     dependencies:
       package-manager-detector: 1.8.0
       tinyexec: 1.3.0
+
+  '@aws-sdk/checksums@3.1000.29':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1121.0':
+    dependencies:
+      '@aws-sdk/checksums': 3.1000.29
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-node': 3.972.81
+      '@aws-sdk/middleware-sdk-s3': 3.972.75
+      '@aws-sdk/signature-v4-multi-region': 3.996.46
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.977.9':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@aws-sdk/xml-builder': 3.972.40
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.33.3
+      '@smithy/signature-v4': 5.7.3
+      '@smithy/types': 4.17.2
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.70':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.72':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.973.15':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-env': 3.972.70
+      '@aws-sdk/credential-provider-http': 3.972.72
+      '@aws-sdk/credential-provider-login': 3.972.77
+      '@aws-sdk/credential-provider-process': 3.972.70
+      '@aws-sdk/credential-provider-sso': 3.973.14
+      '@aws-sdk/credential-provider-web-identity': 3.972.76
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.77':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.81':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.70
+      '@aws-sdk/credential-provider-http': 3.972.72
+      '@aws-sdk/credential-provider-ini': 3.973.15
+      '@aws-sdk/credential-provider-process': 3.972.70
+      '@aws-sdk/credential-provider-sso': 3.973.14
+      '@aws-sdk/credential-provider-web-identity': 3.972.76
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.70':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.973.14':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/token-providers': 3.1116.0
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.76':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/lib-storage@3.1121.0(@aws-sdk/client-s3@3.1121.0)':
+    dependencies:
+      '@aws-sdk/client-s3': 3.1121.0
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      buffer: 5.6.0
+      events: 3.3.0
+      stream-browserify: 3.0.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.75':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/signature-v4-multi-region': 3.996.46
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.44':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/signature-v4-multi-region': 3.996.46
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.46':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@smithy/signature-v4': 5.7.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1116.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.5':
+    dependencies:
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.40':
+    dependencies:
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.3.0': {}
 
   '@babel/generator@8.0.0':
     dependencies:
@@ -3793,6 +4223,39 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.4':
     optional: true
 
+  '@smithy/core@3.33.3':
+    dependencies:
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.5.2':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.7.2':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.11.3':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.7.3':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/types@4.17.2':
+    dependencies:
+      tslib: 2.8.1
+
   '@standard-schema/spec@1.1.0': {}
 
   '@swc/helpers@0.5.23':
@@ -4181,6 +4644,13 @@ snapshots:
       y-protocols: 1.0.7(yjs@13.6.31)
       yjs: 13.6.31
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/esrecurse@4.3.1': {}
 
   '@types/estree@1.0.9': {}
@@ -4308,6 +4778,47 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 7.3.6(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0)
       vue: 3.5.40(typescript@6.0.3)
+
+  '@vitest/expect@4.1.11':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.11(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.11
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.6(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0)
+
+  '@vitest/pretty-format@4.1.11':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.11':
+    dependencies:
+      '@vitest/utils': 4.1.11
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.11':
+    dependencies:
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/utils': 4.1.11
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.11': {}
+
+  '@vitest/utils@4.1.11':
+    dependencies:
+      '@vitest/pretty-format': 4.1.11
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
 
   '@volar/language-core@2.4.28':
     dependencies:
@@ -4483,6 +4994,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  assertion-error@2.0.1: {}
+
   ast-kit@2.2.0:
     dependencies:
       '@babel/parser': 7.29.8
@@ -4500,9 +5013,13 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-js@1.5.1: {}
+
   birpc@2.9.0: {}
 
   boolbase@1.0.0: {}
+
+  bowser@2.14.1: {}
 
   brace-expansion@2.1.4:
     dependencies:
@@ -4519,6 +5036,11 @@ snapshots:
   buffer-crc32@1.0.0: {}
 
   buffer-from@1.1.2: {}
+
+  buffer@5.6.0:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   c12@3.3.4:
     dependencies:
@@ -4539,6 +5061,8 @@ snapshots:
     dependencies:
       pascal-case: 3.1.2
       tslib: 2.8.1
+
+  chai@6.2.2: {}
 
   chokidar@5.0.0:
     dependencies:
@@ -4569,6 +5093,8 @@ snapshots:
   consola@2.15.3: {}
 
   consola@3.4.2: {}
+
+  convert-source-map@2.0.0: {}
 
   cookie-es@1.2.3: {}
 
@@ -4697,6 +5223,8 @@ snapshots:
   entities@7.0.1: {}
 
   errx@0.1.2: {}
+
+  es-module-lexer@2.3.2: {}
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -4858,6 +5386,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  events@3.3.0: {}
+
   execa@8.0.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -4869,6 +5399,8 @@ snapshots:
       onetime: 6.0.0
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
+
+  expect-type@1.4.0: {}
 
   exsolve@1.1.1: {}
 
@@ -5037,6 +5569,8 @@ snapshots:
 
   human-signals@5.0.0: {}
 
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
 
   ignore@7.0.6: {}
@@ -5044,6 +5578,8 @@ snapshots:
   import-meta-resolve@4.2.0: {}
 
   imurmurhash@0.1.4: {}
+
+  inherits@2.0.4: {}
 
   iron-webcrypto@1.2.1: {}
 
@@ -5538,6 +6074,12 @@ snapshots:
       json-parse-even-better-errors: 6.0.0
       npm-normalize-package-bin: 6.0.0
 
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
   readdirp@5.0.0: {}
 
   regexp-tree@0.1.27: {}
@@ -5600,6 +6142,8 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  safe-buffer@5.2.1: {}
+
   scule@1.3.0: {}
 
   semver@7.8.5: {}
@@ -5611,6 +6155,8 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   shell-quote@1.10.0: {}
+
+  siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
 
@@ -5629,7 +6175,18 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  stackback@0.0.2: {}
+
   std-env@4.2.0: {}
+
+  stream-browserify@3.0.0:
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   strip-final-newline@3.0.0: {}
 
@@ -5661,12 +6218,16 @@ snapshots:
 
   tiny-inflate@1.0.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyexec@1.3.0: {}
 
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
+
+  tinyrainbow@3.1.1: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -5865,6 +6426,33 @@ snapshots:
       terser: 5.49.0
       yaml: 2.9.0
 
+  vitest@4.1.11(@types/node@26.1.2)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.11
+      '@vitest/mocker': 4.1.11(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/runner': 4.1.11
+      '@vitest/snapshot': 4.1.11
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      es-module-lexer: 2.3.2
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 7.3.6(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 26.1.2
+    transitivePeerDependencies:
+      - msw
+
   vscode-uri@3.1.0: {}
 
   vue-component-type-helpers@3.3.9: {}
@@ -5948,6 +6536,11 @@ snapshots:
   which@7.0.0:
     dependencies:
       isexe: 4.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/scripts/publishR2.ts
+++ b/scripts/publishR2.ts
@@ -40,6 +40,7 @@ interface ImmutableObjectInput {
   contentDisposition: string;
   cacheControl: string;
   expectedSize: number;
+  expectedSha256: string;
   expectedMetadata: Metadata;
   metadata?: Metadata;
 }
@@ -125,6 +126,10 @@ async function uploadImmutableObject(
   const existing = await headObject(client, input.key);
   if (existing) {
     verifyHead(existing, input.key, input.expectedSize, input.expectedMetadata);
+    const existingSha256 = await sha256Object(client, input.key);
+    if (existingSha256 !== input.expectedSha256) {
+      throw new Error(`R2 对象内容与预期 SHA-256 不一致，拒绝覆盖: ${input.key}`);
+    }
     console.log(`[r2] 对象已存在且校验一致，跳过上传: ${input.key}`);
     return existing;
   }
@@ -150,6 +155,10 @@ async function uploadImmutableObject(
   const uploaded = await headObject(client, input.key);
   if (!uploaded) throw new Error(`上传完成后无法读取 R2 对象: ${input.key}`);
   verifyHead(uploaded, input.key, input.expectedSize, input.expectedMetadata);
+  const uploadedSha256 = await sha256Object(client, input.key);
+  if (uploadedSha256 !== input.expectedSha256) {
+    throw new Error(`上传后 R2 对象内容与预期 SHA-256 不一致: ${input.key}`);
+  }
   return uploaded;
 }
 
@@ -250,6 +259,7 @@ async function publish(client: S3Client, options: CliOptions): Promise<void> {
     contentDisposition: `attachment; filename="${filename}"`,
     cacheControl: 'public, max-age=31536000, immutable',
     expectedSize: size,
+    expectedSha256: actualSha256,
     expectedMetadata: {
       sha256: actualSha256,
       tag: options.tag,
@@ -271,6 +281,7 @@ async function publish(client: S3Client, options: CliOptions): Promise<void> {
     contentDisposition: `attachment; filename="${checksumFilename}"`,
     cacheControl: 'public, max-age=31536000, immutable',
     expectedSize: statSync(checksumPath).size,
+    expectedSha256: await sha256File(checksumPath),
     expectedMetadata: {
       sha256: actualSha256,
       tag: options.tag,
@@ -309,10 +320,11 @@ async function promote(client: S3Client, options: CliOptions): Promise<void> {
     await checksumResponse.Body.transformToString(),
     filename,
   );
-  const metadataSha256 = head.Metadata?.sha256;
-  if (!metadataSha256 && (await sha256Object(client, key)) !== sidecarSha256) {
+  const objectSha256 = await sha256Object(client, key);
+  if (objectSha256 !== sidecarSha256) {
     throw new Error(`R2 对象内容与 checksum 不一致: ${key}`);
   }
+  const metadataSha256 = head.Metadata?.sha256;
   if (metadataSha256 && metadataSha256 !== sidecarSha256) {
     throw new Error(`checksum 与对象 metadata 不一致: ${key}`);
   }

--- a/scripts/publishR2.ts
+++ b/scripts/publishR2.ts
@@ -1,0 +1,350 @@
+import {
+  GetObjectCommand,
+  HeadObjectCommand,
+  PutObjectCommand,
+  S3Client,
+  type HeadObjectCommandOutput,
+} from '@aws-sdk/client-s3';
+import { Upload } from '@aws-sdk/lib-storage';
+import { createHash } from 'node:crypto';
+import { createReadStream, existsSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import { Writable } from 'node:stream';
+import {
+  R2_BUCKET,
+  STABLE_MANIFEST_KEY,
+  createStableManifest,
+  decideStableUpdate,
+  packageFilename,
+  packageObjectKey,
+  parseChecksumSidecar,
+  parseReleaseTag,
+  validateStableManifest,
+  type StableManifest,
+} from './publishR2Core';
+
+type Operation = 'publish' | 'promote';
+type Metadata = Record<string, string>;
+
+interface CliOptions {
+  operation: Operation;
+  tag: string;
+  artifactDir: string;
+}
+
+interface ImmutableObjectInput {
+  localPath: string;
+  key: string;
+  contentType: string;
+  contentDisposition: string;
+  cacheControl: string;
+  expectedSize: number;
+  expectedMetadata: Metadata;
+  metadata?: Metadata;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const operation = argv[0];
+  if (operation !== 'publish' && operation !== 'promote') {
+    throw new Error('用法: publishR2.ts <publish|promote> --tag vX.Y.Z [--artifact-dir DIR]');
+  }
+
+  function readOption(name: string): string | undefined {
+    const index = argv.indexOf(name);
+    return index >= 0 ? argv[index + 1] : undefined;
+  }
+
+  const tag = readOption('--tag');
+  if (!tag) throw new Error('缺少 --tag');
+
+  return {
+    operation,
+    tag,
+    artifactDir: path.resolve(readOption('--artifact-dir') ?? 'releases'),
+  };
+}
+
+function requiredEnv(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`缺少环境变量 ${name}`);
+  return value;
+}
+
+function createR2Client(): S3Client {
+  const accountId = requiredEnv('R2_ACCOUNT_ID');
+  return new S3Client({
+    region: 'auto',
+    endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
+    credentials: {
+      accessKeyId: requiredEnv('R2_ACCESS_KEY_ID'),
+      secretAccessKey: requiredEnv('R2_SECRET_ACCESS_KEY'),
+    },
+  });
+}
+
+function isNotFound(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+  const candidate = error as { name?: string; $metadata?: { httpStatusCode?: number } };
+  return candidate.name === 'NotFound' || candidate.$metadata?.httpStatusCode === 404;
+}
+
+async function headObject(client: S3Client, key: string): Promise<HeadObjectCommandOutput | null> {
+  try {
+    return await client.send(new HeadObjectCommand({ Bucket: R2_BUCKET, Key: key }));
+  } catch (error) {
+    if (isNotFound(error)) return null;
+    throw error;
+  }
+}
+
+function assertMetadata(actual: Metadata | undefined, expected: Metadata, key: string): void {
+  for (const [name, value] of Object.entries(expected)) {
+    if (actual?.[name.toLowerCase()] !== value) {
+      throw new Error(`R2 对象 ${key} 的 metadata.${name} 不匹配`);
+    }
+  }
+}
+
+function verifyHead(
+  head: HeadObjectCommandOutput,
+  key: string,
+  expectedSize: number,
+  expectedMetadata: Metadata,
+): void {
+  if (head.ContentLength !== expectedSize) {
+    throw new Error(`R2 对象 ${key} 大小不匹配`);
+  }
+  assertMetadata(head.Metadata, expectedMetadata, key);
+}
+
+async function uploadImmutableObject(
+  client: S3Client,
+  input: ImmutableObjectInput,
+): Promise<HeadObjectCommandOutput> {
+  const existing = await headObject(client, input.key);
+  if (existing) {
+    verifyHead(existing, input.key, input.expectedSize, input.expectedMetadata);
+    console.log(`[r2] 对象已存在且校验一致，跳过上传: ${input.key}`);
+    return existing;
+  }
+
+  console.log(`[r2] 上传不可变对象: ${input.key}`);
+  const upload = new Upload({
+    client,
+    leavePartsOnError: false,
+    queueSize: 4,
+    partSize: 16 * 1024 * 1024,
+    params: {
+      Bucket: R2_BUCKET,
+      Key: input.key,
+      Body: createReadStream(input.localPath),
+      ContentType: input.contentType,
+      ContentDisposition: input.contentDisposition,
+      CacheControl: input.cacheControl,
+      Metadata: input.metadata ?? input.expectedMetadata,
+    },
+  });
+  await upload.done();
+
+  const uploaded = await headObject(client, input.key);
+  if (!uploaded) throw new Error(`上传完成后无法读取 R2 对象: ${input.key}`);
+  verifyHead(uploaded, input.key, input.expectedSize, input.expectedMetadata);
+  return uploaded;
+}
+
+async function sha256File(filePath: string): Promise<string> {
+  const hash = createHash('sha256');
+  await pipeline(
+    createReadStream(filePath),
+    new Writable({
+      write(chunk: Buffer, _encoding, callback): void {
+        hash.update(chunk);
+        callback();
+      },
+    }),
+  );
+  return hash.digest('hex');
+}
+
+async function sha256Object(client: S3Client, key: string): Promise<string> {
+  const response = await client.send(new GetObjectCommand({ Bucket: R2_BUCKET, Key: key }));
+  if (!response.Body) throw new Error(`R2 对象响应体为空: ${key}`);
+  const hash = createHash('sha256');
+  for await (const chunk of response.Body as AsyncIterable<Uint8Array>) {
+    hash.update(chunk);
+  }
+  return hash.digest('hex');
+}
+
+async function readStableManifest(client: S3Client): Promise<StableManifest | null> {
+  try {
+    const response = await client.send(
+      new GetObjectCommand({ Bucket: R2_BUCKET, Key: STABLE_MANIFEST_KEY }),
+    );
+    if (!response.Body) throw new Error('stable manifest 响应体为空');
+    return validateStableManifest(JSON.parse(await response.Body.transformToString()));
+  } catch (error) {
+    if (isNotFound(error)) return null;
+    throw error;
+  }
+}
+
+async function writeStableManifest(client: S3Client, manifest: StableManifest): Promise<void> {
+  await client.send(
+    new PutObjectCommand({
+      Bucket: R2_BUCKET,
+      Key: STABLE_MANIFEST_KEY,
+      Body: `${JSON.stringify(manifest, null, 2)}\n`,
+      ContentType: 'application/json; charset=utf-8',
+      CacheControl: 'no-store',
+      Metadata: {
+        channel: 'stable',
+        version: manifest.version,
+        tag: manifest.tag,
+        sha256: manifest.sha256,
+      },
+    }),
+  );
+  console.log(`[r2] stable 已切换到 ${manifest.tag}`);
+}
+
+async function publish(client: S3Client, options: CliOptions): Promise<void> {
+  const version = parseReleaseTag(options.tag);
+  const filename = packageFilename(version);
+  const zipPath = path.join(options.artifactDir, filename);
+  const checksumPath = `${zipPath}.sha256`;
+  if (!existsSync(zipPath) || !existsSync(checksumPath)) {
+    throw new Error(`缺少发布文件: ${zipPath} 或 ${checksumPath}`);
+  }
+
+  const size = statSync(zipPath).size;
+  const sidecar = readFileSync(checksumPath, 'utf8');
+  const expectedSha256 = parseChecksumSidecar(sidecar, filename);
+  const actualSha256 = await sha256File(zipPath);
+  if (actualSha256 !== expectedSha256) {
+    throw new Error('本地安装包 SHA-256 与 sidecar 不一致');
+  }
+
+  const current = await readStableManifest(client);
+  const candidate = createStableManifest({
+    version,
+    tag: options.tag,
+    filename,
+    size,
+    sha256: actualSha256,
+    publishedAt: new Date().toISOString(),
+  });
+  if (
+    current?.version === candidate.version &&
+    (current.key !== candidate.key || current.sha256 !== candidate.sha256)
+  ) {
+    throw new Error(`stable 中的 ${options.tag} 与待发布对象不一致，拒绝覆盖`);
+  }
+
+  const key = packageObjectKey(options.tag, filename);
+  const zipHead = await uploadImmutableObject(client, {
+    localPath: zipPath,
+    key,
+    contentType: 'application/zip',
+    contentDisposition: `attachment; filename="${filename}"`,
+    cacheControl: 'public, max-age=31536000, immutable',
+    expectedSize: size,
+    expectedMetadata: {
+      sha256: actualSha256,
+      tag: options.tag,
+      version,
+    },
+    metadata: {
+      sha256: actualSha256,
+      tag: options.tag,
+      version,
+      'published-at': candidate.publishedAt,
+    },
+  });
+
+  const checksumFilename = `${filename}.sha256`;
+  await uploadImmutableObject(client, {
+    localPath: checksumPath,
+    key: `${key}.sha256`,
+    contentType: 'text/plain; charset=utf-8',
+    contentDisposition: `attachment; filename="${checksumFilename}"`,
+    cacheControl: 'public, max-age=31536000, immutable',
+    expectedSize: statSync(checksumPath).size,
+    expectedMetadata: {
+      sha256: actualSha256,
+      tag: options.tag,
+      version,
+      artifact: 'checksum',
+    },
+  });
+
+  const objectPublishedAt = zipHead.Metadata?.['published-at'];
+  if (!objectPublishedAt) throw new Error(`R2 对象 ${key} 缺少 published-at metadata`);
+  const verifiedCandidate = createStableManifest({ ...candidate, publishedAt: objectPublishedAt });
+  const decision = decideStableUpdate(current, verifiedCandidate);
+  if (decision === 'write') {
+    await writeStableManifest(client, verifiedCandidate);
+  } else {
+    console.log(
+      decision === 'skip-same'
+        ? `[r2] ${options.tag} 已是 stable，无需改写`
+        : `[r2] stable 已是更高版本 ${current?.tag}，仅保留 ${options.tag} 归档`,
+    );
+  }
+}
+
+async function promote(client: S3Client, options: CliOptions): Promise<void> {
+  const version = parseReleaseTag(options.tag);
+  const filename = packageFilename(version);
+  const key = packageObjectKey(options.tag, filename);
+  const head = await headObject(client, key);
+  if (!head?.ContentLength) throw new Error(`待提升的 R2 对象不存在: ${key}`);
+
+  const checksumResponse = await client.send(
+    new GetObjectCommand({ Bucket: R2_BUCKET, Key: `${key}.sha256` }),
+  );
+  if (!checksumResponse.Body) throw new Error(`checksum 对象响应体为空: ${key}.sha256`);
+  const sidecarSha256 = parseChecksumSidecar(
+    await checksumResponse.Body.transformToString(),
+    filename,
+  );
+  const metadataSha256 = head.Metadata?.sha256;
+  if (!metadataSha256 && (await sha256Object(client, key)) !== sidecarSha256) {
+    throw new Error(`R2 对象内容与 checksum 不一致: ${key}`);
+  }
+  if (metadataSha256 && metadataSha256 !== sidecarSha256) {
+    throw new Error(`checksum 与对象 metadata 不一致: ${key}`);
+  }
+  if (head.Metadata?.tag && head.Metadata.tag !== options.tag) {
+    throw new Error(`R2 对象 tag metadata 不匹配: ${key}`);
+  }
+  if (head.Metadata?.version && head.Metadata.version !== version) {
+    throw new Error(`R2 对象 version metadata 不匹配: ${key}`);
+  }
+  const publishedAt = head.Metadata?.['published-at'] ?? head.LastModified?.toISOString();
+  if (!publishedAt) throw new Error(`待提升的 R2 对象缺少可用发布时间: ${key}`);
+
+  const manifest = createStableManifest({
+    version,
+    tag: options.tag,
+    filename,
+    size: head.ContentLength,
+    sha256: sidecarSha256,
+    publishedAt,
+  });
+  await writeStableManifest(client, manifest);
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  const client = createR2Client();
+  if (options.operation === 'publish') await publish(client, options);
+  else await promote(client, options);
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`[r2] 发布失败: ${message}`);
+  process.exit(1);
+});

--- a/scripts/publishR2Core.test.ts
+++ b/scripts/publishR2Core.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MAX_CACHEABLE_PACKAGE_SIZE,
+  createStableManifest,
+  decideStableUpdate,
+  packageFilename,
+  parseChecksumSidecar,
+  parseReleaseTag,
+  validateStableManifest,
+} from './publishR2Core';
+
+const SHA_A = 'a'.repeat(64);
+const SHA_B = 'b'.repeat(64);
+
+function manifest(version: string, sha256 = SHA_A) {
+  return createStableManifest({
+    version,
+    tag: `v${version}`,
+    filename: packageFilename(version),
+    size: 1024,
+    sha256,
+    publishedAt: '2026-08-30T12:00:00.000Z',
+  });
+}
+
+describe('R2 release contract', () => {
+  it('accepts canonical release tags and checksum sidecars', () => {
+    expect(parseReleaseTag('v1.2.3')).toBe('1.2.3');
+    expect(
+      parseChecksumSidecar(`${SHA_A}  OEA-windows-x86_64-v1.2.3.zip\n`, packageFilename('1.2.3')),
+    ).toBe(SHA_A);
+  });
+
+  it('rejects malformed tags, filenames and checksum sidecars', () => {
+    expect(() => parseReleaseTag('1.2.3')).toThrow();
+    expect(() => parseReleaseTag('v01.2.3')).toThrow();
+    expect(() => parseChecksumSidecar(`${SHA_A}  wrong.zip`, packageFilename('1.2.3'))).toThrow();
+  });
+
+  it('uses an immutable versioned CDN URL', () => {
+    expect(manifest('1.2.3')).toMatchObject({
+      key: 'releases/oea/v1.2.3/OEA-windows-x86_64-v1.2.3.zip',
+      url: 'https://package.oem.re/releases/oea/v1.2.3/OEA-windows-x86_64-v1.2.3.zip',
+    });
+  });
+
+  it('rejects packages at the 512 MiB cache limit', () => {
+    expect(() =>
+      createStableManifest({
+        version: '1.2.3',
+        tag: 'v1.2.3',
+        filename: packageFilename('1.2.3'),
+        size: MAX_CACHEABLE_PACKAGE_SIZE,
+        sha256: SHA_A,
+        publishedAt: '2026-08-30T12:00:00.000Z',
+      }),
+    ).toThrow(/512 MiB/);
+  });
+
+  it('never moves stable backwards during ordinary publishing', () => {
+    expect(decideStableUpdate(manifest('1.2.3'), manifest('1.2.2'))).toBe('skip-newer-exists');
+    expect(decideStableUpdate(manifest('1.2.3'), manifest('1.2.4'))).toBe('write');
+    expect(decideStableUpdate(manifest('1.2.3'), manifest('1.2.3'))).toBe('skip-same');
+  });
+
+  it('rejects a different object for an already-stable version', () => {
+    expect(() => decideStableUpdate(manifest('1.2.3'), manifest('1.2.3', SHA_B))).toThrow();
+  });
+
+  it('rejects manifests that can redirect outside the fixed CDN contract', () => {
+    expect(() =>
+      validateStableManifest({ ...manifest('1.2.3'), url: 'https://example.com/payload.zip' }),
+    ).toThrow();
+  });
+});

--- a/scripts/publishR2Core.ts
+++ b/scripts/publishR2Core.ts
@@ -1,0 +1,176 @@
+import semver from 'semver';
+
+export const R2_BUCKET = 'opendfieldmap-package';
+export const PACKAGE_APP_ID = 'oea';
+export const PACKAGE_CDN_ORIGIN = 'https://package.oem.re';
+export const STABLE_MANIFEST_KEY = `channels/${PACKAGE_APP_ID}/stable.json`;
+export const MAX_CACHEABLE_PACKAGE_SIZE = 512 * 1024 * 1024;
+
+const SHA256_PATTERN = /^[0-9a-f]{64}$/;
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+export interface StableManifest {
+  schemaVersion: 1;
+  channel: 'stable';
+  version: string;
+  tag: string;
+  filename: string;
+  key: string;
+  url: string;
+  size: number;
+  sha256: string;
+  publishedAt: string;
+}
+
+export type StableUpdateDecision = 'write' | 'skip-same' | 'skip-newer-exists';
+
+export function parseReleaseTag(tag: string): string {
+  if (!tag.startsWith('v')) {
+    throw new Error(`发布 tag 必须以 v 开头: ${tag}`);
+  }
+
+  const version = tag.slice(1);
+  if (!semver.valid(version) || semver.clean(version) !== version) {
+    throw new Error(`发布 tag 不是规范 SemVer: ${tag}`);
+  }
+
+  return version;
+}
+
+export function packageFilename(version: string): string {
+  return `OEA-windows-x86_64-v${version}.zip`;
+}
+
+export function packageObjectKey(tag: string, filename: string): string {
+  return `releases/${PACKAGE_APP_ID}/${tag}/${filename}`;
+}
+
+export function assertCacheablePackageSize(size: number): void {
+  if (!Number.isSafeInteger(size) || size <= 0) {
+    throw new Error(`安装包大小无效: ${size}`);
+  }
+  if (size >= MAX_CACHEABLE_PACKAGE_SIZE) {
+    throw new Error(`安装包大小 ${size} 字节达到 Cloudflare 512 MiB 缓存上限，拒绝发布到 stable`);
+  }
+}
+
+export function parseChecksumSidecar(contents: string, expectedFilename: string): string {
+  const match = contents.trim().match(/^([0-9a-fA-F]{64}) {2}([^\r\n]+)$/);
+  if (!match) {
+    throw new Error('SHA-256 sidecar 格式无效');
+  }
+  if (match[2] !== expectedFilename) {
+    throw new Error(`SHA-256 sidecar 文件名不匹配: ${match[2]}`);
+  }
+  return match[1].toLowerCase();
+}
+
+export function createStableManifest(input: {
+  version: string;
+  tag: string;
+  filename: string;
+  size: number;
+  sha256: string;
+  publishedAt: string;
+}): StableManifest {
+  const expectedVersion = parseReleaseTag(input.tag);
+  if (input.version !== expectedVersion) {
+    throw new Error(`版本 ${input.version} 与 tag ${input.tag} 不一致`);
+  }
+  if (input.filename !== packageFilename(input.version)) {
+    throw new Error(`安装包文件名不符合约定: ${input.filename}`);
+  }
+  assertCacheablePackageSize(input.size);
+  if (!SHA256_PATTERN.test(input.sha256)) {
+    throw new Error('SHA-256 必须是 64 位小写十六进制');
+  }
+  if (!ISO_DATE_PATTERN.test(input.publishedAt) || Number.isNaN(Date.parse(input.publishedAt))) {
+    throw new Error(`publishedAt 不是规范 UTC ISO-8601 时间: ${input.publishedAt}`);
+  }
+
+  const key = packageObjectKey(input.tag, input.filename);
+  return {
+    schemaVersion: 1,
+    channel: 'stable',
+    version: input.version,
+    tag: input.tag,
+    filename: input.filename,
+    key,
+    url: `${PACKAGE_CDN_ORIGIN}/${key}`,
+    size: input.size,
+    sha256: input.sha256,
+    publishedAt: input.publishedAt,
+  };
+}
+
+export function validateStableManifest(value: unknown): StableManifest {
+  if (typeof value !== 'object' || value === null) {
+    throw new Error('stable manifest 必须是对象');
+  }
+
+  const manifest = value as Partial<StableManifest>;
+  const expectedKeys = [
+    'channel',
+    'filename',
+    'key',
+    'publishedAt',
+    'schemaVersion',
+    'sha256',
+    'size',
+    'tag',
+    'url',
+    'version',
+  ];
+  const actualKeys = Object.keys(value).sort();
+  if (
+    actualKeys.length !== expectedKeys.length ||
+    actualKeys.some((key, index) => key !== expectedKeys[index])
+  ) {
+    throw new Error('stable manifest 包含未知字段');
+  }
+  if (manifest.schemaVersion !== 1 || manifest.channel !== 'stable') {
+    throw new Error('stable manifest schema/channel 无效');
+  }
+  if (
+    typeof manifest.version !== 'string' ||
+    typeof manifest.tag !== 'string' ||
+    typeof manifest.filename !== 'string' ||
+    typeof manifest.key !== 'string' ||
+    typeof manifest.url !== 'string' ||
+    typeof manifest.size !== 'number' ||
+    typeof manifest.sha256 !== 'string' ||
+    typeof manifest.publishedAt !== 'string'
+  ) {
+    throw new Error('stable manifest 字段缺失或类型无效');
+  }
+
+  const canonical = createStableManifest({
+    version: manifest.version,
+    tag: manifest.tag,
+    filename: manifest.filename,
+    size: manifest.size,
+    sha256: manifest.sha256,
+    publishedAt: manifest.publishedAt,
+  });
+  if (manifest.key !== canonical.key || manifest.url !== canonical.url) {
+    throw new Error('stable manifest key/url 不符合固定 CDN 契约');
+  }
+
+  return canonical;
+}
+
+export function decideStableUpdate(
+  current: StableManifest | null,
+  candidate: StableManifest,
+): StableUpdateDecision {
+  if (!current) return 'write';
+
+  const comparison = semver.compare(candidate.version, current.version);
+  if (comparison < 0) return 'skip-newer-exists';
+  if (comparison > 0) return 'write';
+
+  if (candidate.key !== current.key || candidate.sha256 !== current.sha256) {
+    throw new Error(`stable 中的 ${candidate.tag} 与待发布对象哈希或路径不同`);
+  }
+  return 'skip-same';
+}


### PR DESCRIPTION
Publish OEA releases to OEM Cloudflare R2

## Sourcery 摘要

通过 Cloudflare R2 分发 OEA 发布版本，同时保留 GitHub 和 MirrorChyan 的协同发布，并确保工件经过验证且不可变，并对稳定渠道的推广进行受控管理。

新功能：
- 将 OEA 发布包发布到 Cloudflare R2，并提供不可变的版本化 URL 和稳定下载渠道。
- 添加手动 R2 发布和推广操作，用于导入发布版本以及执行受保护的回滚。

增强功能：
- 集中构建发布版本，使同一个软件包能够分发到 GitHub Releases、R2 和 MirrorChyan。
- 为发布包和 R2 对象添加 SHA-256 校验文件及验证功能。
- 防止稳定版本回退，或覆盖发生冲突的版本化工件。
- 添加 R2 发布配置、运维指南和稳定下载端点文档。

构建：
- 添加 R2 发布脚本以及 AWS S3/R2 SDK 依赖项。

CI：
- 将发布工作流重构为共享构建、GitHub Release、R2 和 MirrorChyan 任务，并支持工件传递和手动触发。

文档：
- 记录初始 R2 基础设施配置、凭据、CDN 设置、发布流程和回滚步骤。

测试：
- 添加涵盖发布标签、校验和、不可变 URL、软件包大小限制、稳定渠道版本推进以及清单验证的测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过 Cloudflare R2 与现有渠道共同分发 OEA 发布版本，同时强制执行经过验证的不可变构件，并对稳定渠道的推广进行受控管理。

新功能：
- 将 OEA 发布包发布到 Cloudflare R2，提供不可变的版本化下载 URL 和稳定渠道端点。
- 添加手动触发的 R2 发布和推广操作，用于导入发布版本并执行受控回滚。

错误修复：
- 防止覆盖相互冲突的不可变构件，并防止普通发布版本使稳定渠道回退。
- 在发布或推广之前验证包校验和、元数据、清单、发布标签和包大小。

改进：
- 仅构建一次发布包，并在 GitHub Releases、Cloudflare R2 和 MirrorChyan 之间分发共享构件。
- 添加 SHA-256 校验和旁车文件，并对发布包和 R2 对象进行端到端验证。

构建：
- 添加 Cloudflare R2 发布脚本以及 AWS S3/R2 SDK 依赖项。

CI：
- 将发布工作流重构为共享构建、GitHub Release、R2 发布、R2 推广和 MirrorChyan 作业，并支持构件共享和手动操作。

文档：
- 记录 R2 基础设施设置、凭据、CDN 配置、发布流程、稳定端点和回滚操作。

测试：
- 添加针对发布标签、校验和旁车文件、不可变 URL、包大小限制、稳定版本递进和清单验证的契约测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过 Cloudflare R2 与现有渠道一起分发 OEA 发布版本，同时强制执行已验证的不可变构件，并对 stable 渠道的推广进行受控管理。

新功能：
- 将 OEA 发布包发布到 Cloudflare R2，并提供不可变的版本化 URL 和 stable 下载渠道。
- 添加手动触发的 R2 发布和推广操作，用于导入发布版本并执行受控回滚。

错误修复：
- 防止冲突的不可变构件被覆盖，并防止普通发布版本使 stable 渠道回退。
- 在发布或推广之前验证发布标签、包元数据、校验和、清单、对象内容以及包大小。

增强功能：
- 仅构建一次发布包，并通过 GitHub Releases、Cloudflare R2 和 MirrorChyan 分发共享构件。
- 为发布包和 R2 对象添加 SHA-256 伴随文件以及端到端验证。

构建：
- 添加 Cloudflare R2 发布脚本以及 AWS S3/R2 SDK 依赖项。

CI：
- 将发布工作流重构为共享构建、GitHub Release、R2 发布、R2 推广和 MirrorChyan 作业，并支持构件共享和手动操作。

文档：
- 记录 R2 基础设施设置、凭据、CDN 配置、发布流程、stable 端点以及回滚操作。

测试：
- 添加针对发布标签、校验和伴随文件、不可变 URL、包大小限制、stable 版本递进和清单验证的契约测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Distribute OEA releases through Cloudflare R2 alongside existing channels while enforcing verified immutable artifacts and controlled stable-channel promotion.

New Features:
- Publish OEA release packages to Cloudflare R2 with immutable versioned URLs and a stable download channel.
- Add manually triggered R2 publish and promotion operations for importing releases and performing controlled rollbacks.

Bug Fixes:
- Prevent conflicting immutable artifacts from being overwritten and prevent ordinary releases from moving the stable channel backwards.
- Validate release tags, package metadata, checksums, manifests, object contents, and package size before publishing or promotion.

Enhancements:
- Build the release package once and distribute the shared artifact across GitHub Releases, Cloudflare R2, and MirrorChyan.
- Add SHA-256 sidecar files and end-to-end verification for release packages and R2 objects.

Build:
- Add Cloudflare R2 publishing scripts and AWS S3/R2 SDK dependencies.

CI:
- Restructure the release workflow into shared build, GitHub Release, R2 publishing, R2 promotion, and MirrorChyan jobs with artifact sharing and manual operations.

Documentation:
- Document R2 infrastructure setup, credentials, CDN configuration, release procedures, stable endpoints, and rollback operations.

Tests:
- Add contract tests for release tags, checksum sidecars, immutable URLs, package size limits, stable version progression, and manifest validation.

</details>

</details>

</details>