### PR TITLE
fix(tauri): 配置 macOS 上下文 PNG 图标

### DIFF
--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -47,6 +47,8 @@ const bundleName = `${productName}-windows-${arch}-v${version}`;
 const outDir = path.join(rootDir, 'releases');
 const zipPath = path.join(outDir, `${bundleName}.zip`);
 const stagingDir = path.join(outDir, bundleName);
+// Tauri 构建时已将平台图标嵌入可执行文件；Windows 绿色包无需重复携带。
+const WINDOWS_PACKAGE_EXCLUDED_PATHS = new Set([path.join(rootDir, 'resources', 'icons')]);
 
 async function main() {
   // 定位 release 主程序：--no-bundle 构建时二进制沿用 Cargo 包名（如 oea.exe），
@@ -107,12 +109,13 @@ function findReleaseExe(): string | null {
   return exePath ?? null;
 }
 
-// 递归拷贝目录，跳过 `.` 开头的条目（.git、.gitignore 等）
+// 递归拷贝目录，跳过 `.` 开头的条目以及打包时无需复制的构建资源
 function copyDirFiltered(src: string, dest: string) {
   mkdirSync(dest, { recursive: true });
   for (const entry of readdirSync(src)) {
     if (entry.startsWith('.')) continue;
     const s = path.join(src, entry);
+    if (WINDOWS_PACKAGE_EXCLUDED_PATHS.has(s)) continue;
     const d = path.join(dest, entry);
     if (statSync(s).isDirectory()) copyDirFiltered(s, d);
     else copyFileSync(s, d);

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,6 +18,7 @@
     "active": true,
     "targets": [],
     "icon": [
+      "../resources/icons/icon.png",
       "../resources/icons/icon.ico"
     ],
     "android": {


### PR DESCRIPTION
> This message is generated by AI.

## 背景

OEA 的 Tauri 配置目前只列出 Windows 使用的 `.ico` 图标。`generate_context!()` 会按目标平台选择不同格式：Windows 选择 `.ico`，macOS 选择 `.png`。由于配置中没有 PNG，macOS 会回退到未跟踪的 `src-tauri/icons/icon.png`，导致干净检出无法直接编译。

为让应用上下文在两个平台上都从受版本控制的资源生成，本 PR 显式配置资源子模块提供的 PNG，同时保留现有 ICO。

## 依赖状态

- https://github.com/Logical-Byte/oea-resource/pull/1 已合并。
- `resources` 子模块已更新到对应的 `oea-resource/main` 合并提交 `b4611e5`。

## 变更

- 在 `tauri.conf.json` 的 `bundle.icon` 中加入 `../resources/icons/icon.png`。
- 更新 `resources` 子模块引用，使 PNG 图标随干净检出提供。
- 不再依赖本地、未跟踪的 `src-tauri/icons/icon.png`。
- Windows 绿色包跳过仅在构建时使用的 `resources/icons` 目录，避免重复携带已嵌入可执行文件的 PNG 和 ICO。

## 验证

在 `src-tauri/icons/icon.png` 不存在的情况下完成：

- macOS arm64 `cargo build --all-targets` 通过，并生成 Mach-O 可执行文件。
- Windows x86-64 MSVC `cargo xwin build --all-targets` 通过，并生成 PE32+ 可执行文件。
- `pnpm tauri build --no-bundle` 通过，完整执行模型准备、Vite 生产构建和 macOS Rust release 构建。
- 实际执行 Windows 绿色包组装后，暂存目录和 ZIP 均不含 `resources/icons`，其他运行时资源仍正常包含。

## Summary by Sourcery

完善跨平台 Tauri 图标资源配置并精简 Windows 绿色包内容。

Bug Fixes:
- 为 macOS Tauri 构建显式配置受版本控制的 PNG 图标，避免干净检出因缺少本地图标资源而构建失败。

Enhancements:
- 更新资源子模块以提供 PNG 图标，并保留现有 Windows ICO 图标配置。

Build:
- 调整 Windows 绿色包打包逻辑，排除已嵌入可执行文件的图标资源目录，避免重复分发。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

完善跨平台 Tauri 图标资源配置并精简 Windows 绿色包内容。

Bug Fixes:
- 为 macOS Tauri 构建显式配置受版本控制的 PNG 图标，避免干净检出因缺少本地图标资源而构建失败。

Enhancements:
- 更新资源子模块以提供 PNG 图标，并保留现有 Windows ICO 图标配置。

Build:
- 调整 Windows 绿色包打包逻辑，排除已嵌入可执行文件的图标资源目录，避免重复分发。

</details>