### PR TITLE
docs: 记录 OCR 模型来源

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ OEA：一键识别终末地档案库，并同步到 OEM（终末地地图集）�
 - [终末地地图集](https://oem.re/)
 - [逻辑元LogicalByte](https://space.bilibili.com/688411531)
 - [Mirror酱](https://mirrorchyan.com/)
+- [RapidAI/RapidOCR](https://github.com/RapidAI/RapidOCR)（[模型仓库](https://www.modelscope.cn/models/RapidAI/RapidOCR)、[第三方组件说明](docs/third-party-notices.md)）
 - [MaaXYZ/MaaFramework](https://github.com/MaaXYZ/MaaFramework)
 - [MistEO/MXU](https://github.com/MistEO/MXU)
 - [MaaEnd/MaaEnd](https://github.com/MaaEnd/MaaEnd)

--- a/docs/third-party-notices.md
+++ b/docs/third-party-notices.md
@@ -1,0 +1,15 @@
+# 第三方组件
+
+## RapidOCR OCR 模型
+
+OEA 使用以下 OCR 模型文件：
+
+- `resources/ocr-models/PP-OCRv6_rec_tiny.onnx`
+- `resources/ocr-models/ppocrv6_tiny_dict.txt`
+
+来源：
+
+- [RapidAI/RapidOCR 模型仓库（ModelScope）](https://www.modelscope.cn/models/RapidAI/RapidOCR)
+- [RapidAI/RapidOCR 项目（GitHub）](https://github.com/RapidAI/RapidOCR)
+
+本页仅记录第三方文件的来源，不对上游未随模型仓库提供的许可证作补充或推断。

--- a/src/pages/help.vue
+++ b/src/pages/help.vue
@@ -354,6 +354,26 @@ onBeforeUnmount(() => {
             <UButton
               class="px-0"
               color="primary"
+              label="RapidAI/RapidOCR (GitHub)"
+              rel="noopener noreferrer"
+              target="_blank"
+              to="https://github.com/RapidAI/RapidOCR"
+              trailing-icon="i-simple-icons:github"
+              variant="link"
+            />
+            <UButton
+              class="px-0"
+              color="primary"
+              label="RapidAI/RapidOCR 模型 (ModelScope)"
+              rel="noopener noreferrer"
+              target="_blank"
+              to="https://www.modelscope.cn/models/RapidAI/RapidOCR"
+              trailing-icon="i-lucide-external-link"
+              variant="link"
+            />
+            <UButton
+              class="px-0"
+              color="primary"
               label="MaaXYZ/MaaFramework"
               rel="noopener noreferrer"
               target="_blank"


### PR DESCRIPTION
> This message is generated by AI.

## 背景

OEA 使用 RapidOCR 提供的 PP-OCRv6 模型。由于 ModelScope 模型仓库未实际附带许可证文件，本 PR 不补充或推断其许可证，仅保留可核验的上游来源。

## 变更

- 在应用帮助页加入 RapidOCR 的 ModelScope 模型仓库与 GitHub 项目链接
- 在 `docs/third-party-notices.md` 记录 OCR 模型文件及其来源
- 在 README 中链接 RapidOCR、模型仓库与第三方组件说明
- 第三方声明仅保留在仓库中，不加入发行包

## 验证

通过前端类型检查、lint 与格式检查。未新增自动化测试。

## Sourcery 摘要

记录 RapidOCR 模型来源，并让其上游项目、模型仓库和第三方声明更易于访问。

新功能：
- 在应用帮助页面和 README 中添加 RapidOCR 项目和 ModelScope 模型链接。

增强功能：
- 记录 OCR 模型文件及其可验证的上游来源，但不推断许可条款。

文档：
- 添加第三方声明，记录 RapidOCR OCR 模型文件及其上游仓库。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

补充 RapidOCR OCR 模型的上游来源说明，并提升相关项目与第三方声明的可访问性。

Documentation:
- 记录 OEA 使用的 RapidOCR PP-OCRv6 OCR 模型文件及其可核验的 GitHub 和 ModelScope 上游来源。
- 在应用帮助页和 README 中提供 RapidOCR 项目、模型仓库及第三方组件说明的访问链接。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

补充 RapidOCR OCR 模型的上游来源说明，并提升相关项目与第三方声明的可访问性。

Documentation:
- 记录 OEA 使用的 RapidOCR PP-OCRv6 OCR 模型文件及其可核验的 GitHub 和 ModelScope 上游来源。
- 在应用帮助页和 README 中提供 RapidOCR 项目、模型仓库及第三方组件说明的访问链接。

</details>

</details>