### PR TITLE
fix(ci): 修复 Windows 格式检查与注册表测试

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/src-tauri/src/windows_ops/registry.rs
+++ b/src-tauri/src/windows_ops/registry.rs
@@ -221,10 +221,10 @@ mod tests {
 
     #[test]
     fn test_read_registry_dword_type_mismatch() {
-        // ProxyServer 是 REG_SZ，用 DWORD 读取应返回类型错误。
-        let hkey = HKEY_CURRENT_USER;
-        let subkey = r"Software\Microsoft\Windows\CurrentVersion\Internet Settings";
-        let value_name = "ProxyServer";
+        // ProductName 是所有受支持 Windows 版本都有的 REG_SZ，用 DWORD 读取应返回类型错误。
+        let hkey = HKEY_LOCAL_MACHINE;
+        let subkey = r"SOFTWARE\Microsoft\Windows NT\CurrentVersion";
+        let value_name = "ProductName";
 
         let result = read_registry_dword(hkey, subkey, value_name);
         dbg!(&result);


### PR DESCRIPTION
> This message is generated by AI.

## 背景

近期 `main` 分支的前后端 CI 同时失败，但应用代码本身可以正常构建。

前端 CI 在 Windows 上运行格式检查。Git 签出时会将文本文件转换为 CRLF，而项目通过 EditorConfig 和 Prettier 统一使用 LF，因此 Prettier 将几乎所有文本文件都报告为格式不一致。

后端 CI 的注册表类型测试依赖当前用户配置中的 `ProxyServer`。该值只有在用户配置过代理时才存在，干净的 CI 环境会正确返回“值不存在”，导致测试误判失败。

## 处理

- 增加 `.gitattributes`，让所有平台签出的文本文件统一使用 LF。
- 将注册表类型测试改为读取 Windows 固有的 `ProductName` 字符串值，继续覆盖“用 DWORD 类型读取字符串应返回类型错误”的行为，同时移除对用户代理配置的依赖。

## 验证

- `pnpm run build`
- `pnpm fix`
- `pnpm run check`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- `cargo check --manifest-path src-tauri/Cargo.toml --all-targets`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `cargo xwin check --manifest-path src-tauri/Cargo.toml --target x86_64-pc-windows-msvc --all-targets`
- `cargo xwin clippy --manifest-path src-tauri/Cargo.toml --target x86_64-pc-windows-msvc --all-targets -- -D warnings`
- `cargo xwin build --manifest-path src-tauri/Cargo.toml --target x86_64-pc-windows-msvc`

## Sourcery 总结

稳定 Windows CI 格式检查和注册表测试，确保其在干净环境中正常运行。

Bug 修复：
- 防止 Windows 格式检查因平台相关的换行符而失败。
- 使用内置的 ProductName 值替代可选的代理设置，使注册表类型不匹配测试在干净的 CI 环境中可靠运行。

构建：
- 在各个平台上统一将检出的文本文件标准化为 LF。

测试：
- 更新 Windows 注册表类型不匹配测试，使其使用始终可用的系统字符串值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Stabilize Windows CI formatting and registry tests across clean environments.

Bug Fixes:
- Prevent Windows formatting checks from failing due to platform-dependent line endings.
- Make the registry type-mismatch test reliable in clean CI environments by using the built-in ProductName value instead of optional proxy settings.

Build:
- Standardize checked-out text files to LF across platforms.

Tests:
- Update the Windows registry type-mismatch test to use a consistently available system string value.

</details>