### PR TITLE
ci: 减少重复与无关的后端检查

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,10 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v*'
   pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -75,7 +78,7 @@ jobs:
   backend-ci:
     name: Backend CI
     needs: changes
-    if: needs.changes.outputs.backend == 'true'
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v') || needs.changes.outputs.backend == 'true'
     runs-on: windows-latest
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,13 +79,11 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        id: checkout
         uses: actions/checkout@v7
         with:
           submodules: recursive
 
       - name: Setup rust
-        id: setup_rust
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
@@ -96,14 +94,25 @@ jobs:
           workspaces: 'src-tauri -> target'
 
       - name: Backend format check
+        id: fmt
+        continue-on-error: true
         working-directory: src-tauri
         run: cargo fmt --all -- --check
 
       - name: Backend test
+        id: test
+        continue-on-error: true
         working-directory: src-tauri
         run: cargo test
 
       - name: Backend clippy
-        if: ${{ !cancelled() && steps.checkout.outcome == 'success' && steps.setup_rust.outcome == 'success' }}
         working-directory: src-tauri
         run: cargo clippy --all-targets -- -D warnings
+
+      - name: Propagate backend failures
+        if: ${{ !cancelled() }}
+        shell: pwsh
+        run: |
+          if ("${{ steps.fmt.outcome }}" -eq "failure" -or "${{ steps.test.outcome }}" -eq "failure") {
+            exit 1
+          }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,11 +79,13 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
+        id: checkout
         uses: actions/checkout@v7
         with:
           submodules: recursive
 
       - name: Setup rust
+        id: setup_rust
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
@@ -102,5 +104,6 @@ jobs:
         run: cargo test
 
       - name: Backend clippy
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' && steps.setup_rust.outcome == 'success' }}
         working-directory: src-tauri
         run: cargo clippy --all-targets -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 concurrency:
@@ -9,6 +11,33 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect backend changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Detect backend changes
+        id: filter
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            backend:
+              - '.cargo/**'
+              - '.github/workflows/ci.yml'
+              - '.gitattributes'
+              - '.gitmodules'
+              - 'resources'
+              - 'rust-toolchain'
+              - 'rust-toolchain.toml'
+              - 'src-tauri/**'
+
   frontend-ci:
     name: Frontend CI
     runs-on: windows-latest
@@ -45,6 +74,8 @@ jobs:
 
   backend-ci:
     name: Backend CI
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -62,14 +93,6 @@ jobs:
         with:
           workspaces: 'src-tauri -> target'
 
-      - name: Backend check
-        working-directory: src-tauri
-        run: cargo check --all-targets
-
-      - name: Backend clippy
-        working-directory: src-tauri
-        run: cargo clippy --all-targets -- -D warnings
-
       - name: Backend format check
         working-directory: src-tauri
         run: cargo fmt --all -- --check
@@ -77,3 +100,7 @@ jobs:
       - name: Backend test
         working-directory: src-tauri
         run: cargo test
+
+      - name: Backend clippy
+        working-directory: src-tauri
+        run: cargo clippy --all-targets -- -D warnings


### PR DESCRIPTION
> This message is generated by AI.

## 背景

当前 CI 会同时响应功能分支的 `push` 和 `pull_request` 事件，同一个提交因此执行两遍前后端检查。后端检查还会在纯前端或文档改动时完整编译 Rust 依赖，冷缓存下单次需要十余分钟。

此外，后端依次运行 `cargo check`、Clippy 和测试。Clippy 已包含类型检查，而测试需要生成并链接完整机器码，难以复用 Clippy 产生的轻量检查产物。

## 调整

- 功能分支仅通过 `pull_request` 触发 CI，`push` 事件只保留给 `main`。
- 推送 `v*` 发布标签或手动运行工作流时，强制执行完整前后端 CI。
- 前端 CI 继续对所有改动运行。
- 增加轻量路径检测，仅在 Rust、资源子模块或相关 CI 配置变化时运行后端 CI。
- 移除单独的 `cargo check`，并将后端顺序调整为格式检查、测试、Clippy，使 Clippy 尽量复用测试阶段的完整依赖构建产物。
- 格式检查和测试失败时继续执行后续步骤，最后统一传播真实结果，确保一次 CI 运行提供完整诊断且不会误报成功。

## 验证

- 工作流 YAML 解析通过。
- `pnpm exec prettier --check .github/workflows/ci.yml`
- `pnpm fix`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`

## Sourcery 总结

优化 CI 触发条件和后端验证流程，在保留全面失败报告的同时，减少重复和不必要的检查。

改进：
- 通过将推送触发的工作流限制为 `main` 和发布标签，减少冗余的 CI 运行，同时保留拉取请求和手动触发。
- 当更改仅涉及无关的前端或文档文件时，跳过后端 CI，同时保留发布和手动运行的完整检查。
- 通过移除单独的 Cargo 检查，并对格式检查、测试和 Clippy 进行排序，简化后端验证流程，从而提升诊断覆盖率并复用构建结果。
- 确保在后续后端检查完成后，再报告格式和测试失败。

CI：
- 添加后端更改检测，根据相关 Rust、资源和 CI 配置文件的更改，有条件地运行后端检查。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize CI triggers and backend validation to reduce duplicate and unnecessary checks while preserving comprehensive failure reporting.

Enhancements:
- Reduce redundant CI runs by limiting push-triggered workflows to main and release tags while retaining pull request and manual triggers.
- Skip backend CI when changes are limited to unrelated frontend or documentation files, while preserving full checks for releases and manual runs.
- Streamline backend validation by removing the separate Cargo check and ordering formatting, tests, and Clippy to improve diagnostic coverage and build reuse.
- Ensure formatting and test failures are reported after subsequent backend checks complete.

CI:
- Add backend change detection to conditionally run backend checks based on relevant Rust, resource, and CI configuration changes.

</details>