### PR TITLE
refactor(任务): 用单一场景表达任务前置条件

### DIFF
--- a/src-tauri/src/task/archive_scan/task.rs
+++ b/src-tauri/src/task/archive_scan/task.rs
@@ -43,29 +43,8 @@ impl Task for ArchiveScanTask {
         "扫描档案库"
     }
 
-    fn supported_entry_scenes(&self) -> &[SceneId] {
-        // 任务支持从任意档案库相关界面、协议终端或大世界开始：
-        // - 大世界 → 自动导航到 协议终端 → 档案库主界面
-        // - 协议终端 → 自动导航到 档案库主界面
-        // - 档案库主界面 → 无需导航，直接开始扫描
-        // - 档案库子界面（任意分类）→ 自动导航到 档案库主界面
-        // - 档案详情页面 → 自动导航到 档案库子界面 → 档案库主界面
-        static ENTRIES: std::sync::LazyLock<Vec<SceneId>> = std::sync::LazyLock::new(|| {
-            use 档案库SubSceneId::*;
-            vec![
-                SceneId::大世界,
-                SceneId::协议终端,
-                SceneId::档案库主界面,
-                SceneId::档案库子界面(音像存档_多媒体),
-                SceneId::档案库子界面(见闻辑录_纸质记录),
-                SceneId::档案库子界面(见闻辑录_电子档案),
-                SceneId::档案库子界面(见闻辑录_藏品),
-                SceneId::档案库子界面(中枢档案_中枢档案),
-                SceneId::档案库子界面(中枢档案_调查报告),
-                SceneId::档案详情页面,
-            ]
-        });
-        &ENTRIES
+    fn precondition_scene(&self) -> SceneId {
+        SceneId::档案库主界面
     }
 
     fn run(&self, session: &mut Session, scene_manager: &SceneManager) -> Result<()> {

--- a/src-tauri/src/task/mod.rs
+++ b/src-tauri/src/task/mod.rs
@@ -1,13 +1,13 @@
 //! 任务系统模块。
 //!
 //! `Task` trait 是脚本的扩展点：每个自动化脚本实现一个 Task。
-//! [`run_task`] 提供通用启动流程：检测当前场景 → 不在入口列表则导航到第一个入口 → 执行任务。
+//! [`run_task`] 提供通用启动流程：满足任务的前置场景 → 执行任务。
 //!
 //! 任务运行中的导航一律委托 [`crate::scene::SceneManager`]，Task 只写业务节奏。
 
 pub mod archive_scan;
 
-use anyhow::{Result, bail};
+use anyhow::Result;
 
 use crate::{
     scene::{SceneId, scene_manager::SceneManager},
@@ -36,11 +36,10 @@ pub trait Task {
     /// 任务名称（用于日志）。
     fn name(&self) -> &str;
 
-    /// 任务支持的入口场景列表。
+    /// 任务执行所需的前置场景。
     ///
-    /// 任务可以从这些场景中的任意一个开始执行；不在列表中时 [`run_task`]
-    /// 会导航到第一个入口场景。
-    fn supported_entry_scenes(&self) -> &[SceneId];
+    /// [`run_task`] 会在调用 [`Task::run`] 前导航到该场景。
+    fn precondition_scene(&self) -> SceneId;
 
     /// 执行任务主逻辑。
     ///
@@ -48,7 +47,7 @@ pub trait Task {
     fn run(&self, session: &mut Session, scenes: &SceneManager) -> Result<()>;
 }
 
-/// 运行任务：检测当前场景 → 不在入口列表则导航到第一个入口 → 执行任务。
+/// 运行任务：满足任务的前置场景 → 执行任务。
 pub fn run_task(task: &dyn Task, session: &mut Session, scenes: &SceneManager) -> Result<()> {
     tracing::info!("========== 开始执行任务: {} ==========", task.name());
 
@@ -56,28 +55,10 @@ pub fn run_task(task: &dyn Task, session: &mut Session, scenes: &SceneManager) -
     //    按钮 hover 样式变化干扰首次场景识别 / 导航。
     session.move_mouse_to_safe_position()?;
 
-    // 1. 检测当前场景
-    let current = scenes.detect_current_scene(session)?;
+    // 1. 满足任务的前置场景
+    scenes.ensure_scene(task.precondition_scene(), session)?;
 
-    // 2. 不在支持的入口场景中则导航到第一个入口
-    if !task.supported_entry_scenes().contains(&current) {
-        let target = task
-            .supported_entry_scenes()
-            .first()
-            .copied()
-            .unwrap_or(SceneId::未知);
-        if target == SceneId::未知 {
-            bail!("任务 {} 无有效入口场景", task.name());
-        }
-        tracing::info!(
-            "当前场景 {:?} 不在任务入口列表中，导航到 {:?}",
-            current,
-            target
-        );
-        scenes.navigate_to(target, session)?;
-    }
-
-    // 3. 执行任务
+    // 2. 执行任务
     task.run(session, scenes)?;
 
     tracing::info!("========== 任务 {} 执行完毕 ==========", task.name());


### PR DESCRIPTION
> This message is generated by AI.

## 背景

`Task::supported_entry_scenes` 同时表达了“可以从哪些场景启动”和“不在列表时导航到哪里”两层含义。对档案库扫描任务来说，列表已包含所有可识别的具体场景，而任务真正需要的前置条件始终只有一个：进入档案库主界面。这使入口集合掩盖了任务的真实约束，其首元素回退规则也无法恢复未知场景。

因此，本 PR 将任务入口收窄为单一、明确的前置场景。`run_task` 在执行任务前通过 `SceneManager` 满足这一前置条件；当场景未知或不可达时，由 `SceneManager` 返回错误。

## 设计变化

```diff
 pub trait Task {
-    fn supported_entry_scenes(&self) -> &[SceneId];
+    fn precondition_scene(&self) -> SceneId;
 }
```

```mermaid
flowchart TB
    subgraph before["改动前：入口集合混合两种语义"]
        A["supported_entry_scenes()<br/>[大世界, 协议终端, 档案库主界面, ...]"] --> B{"当前场景在集合中？"}
        B -->|"是"| C["跳过通用导航"]
        B -->|"否"| D["导航到集合首项"]
        C --> E["ArchiveScanTask::run<br/>ensure_scene(档案库主界面)"]
        D --> E
    end

    subgraph after["改动后：任务只声明真实前置条件"]
        F["precondition_scene()<br/>档案库主界面"] --> G["run_task<br/>ensure_scene(前置场景)"]
        G -->|"可达"| H["Task::run"]
        G -->|"未知 / 不可达"| I["返回 SceneManager 错误"]
    end
```

任务只负责声明“执行前必须在哪里”；当前场景能否到达该目标，由拥有导航图的 `SceneManager` 判定。

## 改动

- 将 `Task::supported_entry_scenes` 替换为返回单个 `SceneId` 的 `Task::precondition_scene`。
- 让 `run_task` 在调用 `Task::run` 前通过 `ensure_scene` 满足前置场景。
- 将档案库扫描任务的前置场景明确为 `SceneId::档案库主界面`。

## 验证

- `cargo fmt --all -- --check`
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo xwin check --target x86_64-pc-windows-msvc --all-targets`
- `cargo xwin clippy --target x86_64-pc-windows-msvc --all-targets -- -D warnings`
- `cargo xwin build --target x86_64-pc-windows-msvc`

## Sourcery 摘要

在运行任务的主要逻辑之前，为每个任务声明并强制执行一个前置条件场景。

Bug 修复：
- 确保任务在执行前导航至其实际所需的场景，并由 SceneManager 报告未知或无法到达的场景。

改进：
- 将任务入口场景列表替换为单个明确的前置条件场景。
- 简化通用任务运行器，将场景验证和导航完全交由 SceneManager 处理。
- 将归档扫描任务的前置条件设置为归档主界面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Declare and enforce a single precondition scene for each task before running its main logic.

Bug Fixes:
- Ensure tasks are navigated to their actual required scene before execution, with unknown or unreachable scenes reported by SceneManager.

Enhancements:
- Replace task entry-scene lists with a single explicit precondition scene.
- Simplify the common task runner to delegate scene validation and navigation entirely to SceneManager.
- Set the archive scan task's precondition to the archive main interface.

</details>