### PR TITLE
perf(场景): 减少任务前置场景的重复识别

### DIFF
--- a/src-tauri/src/scene/scene_manager.rs
+++ b/src-tauri/src/scene/scene_manager.rs
@@ -58,10 +58,21 @@ impl SceneManager {
     ///
     /// 场景按注册顺序排列识别优先级——应先注册更具体的场景（如"档案详情页面"），
     /// 再注册更笼统的场景（如"大世界"、"未知"）。
+    ///
+    /// # Panics
+    ///
+    /// 同一个 `SceneId` 变体只能注册一个场景识别器。带负载的变体应由同一个
+    /// 识别器返回具体 ID，例如 `档案库子界面`。
     pub fn register(&mut self, scene: Box<dyn Scene>) {
         let id = scene.id();
         let idx = self.scenes.len();
-        self.scene_index.insert(discriminant(&id), idx);
+        let key = discriminant(&id);
+        assert!(
+            !self.scene_index.contains_key(&key),
+            "同一 SceneId 变体重复注册: {:?}",
+            id
+        );
+        self.scene_index.insert(key, idx);
         self.scenes.push(scene);
     }
 

--- a/src-tauri/src/scene/scene_manager.rs
+++ b/src-tauri/src/scene/scene_manager.rs
@@ -6,6 +6,7 @@
 
 use std::{
     collections::{HashMap, VecDeque},
+    mem::{Discriminant, discriminant},
     thread,
     time::Duration,
 };
@@ -37,8 +38,8 @@ fn normalize_scene_id(id: SceneId) -> SceneId {
 pub struct SceneManager {
     /// 所有已注册的场景（按优先级排序，越具体的场景越靠前）
     scenes: Vec<Box<dyn Scene>>,
-    /// 场景 ID → 索引的快速查找表
-    scene_index: HashMap<SceneId, usize>,
+    /// 场景 ID 变体 → 索引的快速查找表
+    scene_index: HashMap<Discriminant<SceneId>, usize>,
     /// 导航图：scene_id → 所有可达的 (target_id, transition_index)
     navigation_graph: HashMap<SceneId, Vec<(SceneId, usize)>>,
 }
@@ -60,7 +61,7 @@ impl SceneManager {
     pub fn register(&mut self, scene: Box<dyn Scene>) {
         let id = scene.id();
         let idx = self.scenes.len();
-        self.scene_index.insert(id, idx);
+        self.scene_index.insert(discriminant(&id), idx);
         self.scenes.push(scene);
     }
 
@@ -136,6 +137,18 @@ impl SceneManager {
             thread::sleep(Duration::from_millis(200));
         }
         Ok(false)
+    }
+
+    /// 检查当前是否为指定场景，不执行导航。
+    ///
+    /// 仅调用期望场景对应的识别器，避免遍历所有已注册场景。
+    /// 对于档案库子界面，识别结果必须与期望的具体子界面完全一致。
+    pub fn require_scene(&self, expected: SceneId, session: &mut Session) -> Result<()> {
+        if self.recognizes_scene(expected, session)? {
+            Ok(())
+        } else {
+            bail!("当前场景不符合预期: {:?}", expected)
+        }
     }
 
     // ========== 场景导航 ==========
@@ -254,15 +267,37 @@ impl SceneManager {
     }
 
     /// 确保当前处于目标场景，如果不在则自动导航过去。
+    ///
+    /// 先仅调用目标场景的识别器；识别不匹配时再执行完整导航。
     pub fn ensure_scene(&self, target: SceneId, session: &mut Session) -> Result<()> {
-        let current = self.detect_current_scene(session)?;
-        if current == target {
+        if self.recognizes_scene(target, session)? {
             return Ok(());
         }
         self.navigate_to(target, session)
     }
 
     // ========== 内部方法 ==========
+
+    /// 根据场景 ID 变体查找已注册的场景识别器。
+    fn get_registered_scene(&self, hint: SceneId) -> Option<&dyn Scene> {
+        let idx = self.scene_index.get(&discriminant(&hint))?;
+        Some(self.scenes[*idx].as_ref())
+    }
+
+    /// 仅使用期望场景的识别器检查当前场景。
+    fn recognizes_scene(&self, expected: SceneId, session: &mut Session) -> Result<bool> {
+        if expected == SceneId::未知 {
+            bail!("未知场景不能作为预期场景");
+        }
+
+        let scene = self
+            .get_registered_scene(expected)
+            .ok_or_else(|| anyhow::anyhow!("未注册的场景: {:?}", expected))?;
+        let recognized = scene
+            .try_recognize(session)
+            .with_context(|| format!("场景识别出错 ({})", scene.name()))?;
+        Ok(recognized == Some(expected))
+    }
 
     /// BFS 寻找从 `from` 到 `to` 的最短路径。
     ///
@@ -318,13 +353,9 @@ impl SceneManager {
 
     /// 执行单步跳转：从 `from` 场景跳转到 `to` 场景。
     fn execute_single_step(&self, from: SceneId, to: SceneId, session: &mut Session) -> Result<()> {
-        // 归一化 档案库子界面 的 variants 以便在 scene_index 中查找
-        let lookup_id = normalize_scene_id(from);
-        let &idx = self
-            .scene_index
-            .get(&lookup_id)
+        let scene = self
+            .get_registered_scene(from)
             .ok_or_else(|| anyhow::anyhow!("未注册的场景: {:?}", from))?;
-        let scene = &self.scenes[idx];
         scene.execute_transition(to, session)
     }
 }

--- a/src-tauri/src/task/archive_scan/task.rs
+++ b/src-tauri/src/task/archive_scan/task.rs
@@ -48,11 +48,7 @@ impl Task for ArchiveScanTask {
     }
 
     fn run(&self, session: &mut Session, scene_manager: &SceneManager) -> Result<()> {
-        // Step 1: 确保在档案库主界面
-        info!("导航到档案库主界面...");
-        scene_manager.ensure_scene(SceneId::档案库主界面, session)?;
-
-        // Step 2: 遍历所有子分类
+        // Step 1: 遍历所有子分类
         for (step_idx, step) in SCAN_PLAN.iter().enumerate() {
             info!(
                 "===== 扫描子分类 {}/{}: {:?} =====",
@@ -61,10 +57,10 @@ impl Task for ArchiveScanTask {
                 step.first_sub_scene
             );
 
-            // 2a. 从档案库主界面点击入口按钮进入子分类
+            // 1a. 从档案库主界面点击入口按钮进入子分类
             self.enter_sub_scene_from_main(session, scene_manager, step)?;
 
-            // 2b. 遍历该分类下的所有子界面
+            // 1b. 遍历该分类下的所有子界面
             for (sub_idx, &sub_scene) in step.sub_scenes.iter().enumerate() {
                 if sub_idx > 0 {
                     // 不是第一个子界面，需要点击侧边栏 tab 切换（索引即 tab 序号）
@@ -88,7 +84,7 @@ impl Task for ArchiveScanTask {
                 info!("完成扫描 {:?}", sub_scene);
             }
 
-            // 2c. 返回档案库主界面（准备进入下一个子分类）
+            // 1c. 返回档案库主界面（准备进入下一个子分类）
             info!("返回档案库主界面...");
             scene_manager.navigate_to(SceneId::档案库主界面, session)?;
         }
@@ -100,14 +96,15 @@ impl Task for ArchiveScanTask {
 
 impl ArchiveScanTask {
     /// 从档案库主界面点击入口按钮进入子分类。
+    ///
+    /// 调用时应已处于档案库主界面。
     fn enter_sub_scene_from_main(
         &self,
         session: &mut Session,
         scene_manager: &SceneManager,
         step: &ScanStep,
     ) -> Result<()> {
-        // 确保在主界面
-        scene_manager.ensure_scene(SceneId::档案库主界面, session)?;
+        scene_manager.require_scene(SceneId::档案库主界面, session)?;
 
         // 截图并搜索入口按钮
         let screenshot = session.screencap_for_recognition()?;


### PR DESCRIPTION
> This message is generated by AI.

## 背景

#39 让 `run_task` 在任务启动时统一满足前置场景，但档案库任务仍会重复检查同一前置条件。同时，`ensure_scene` 已经知道期望的目标场景，快速路径却仍会遍历全部场景识别器；如果需要导航，`navigate_to` 随后还会再次执行完整场景检测。

本 PR 将“已知期望场景的定向检查”与“不知道当前场景时的完整导航”分开：常见的匹配路径只调用一个识别器，不匹配时仍会进入 `navigate_to` 完成恢复。

## 设计

```mermaid
flowchart LR
    A["ensure_scene(expected)"] --> B["只调用 expected 对应的识别器"]
    B -->|"精确匹配"| C["Ok"]
    B -->|"不匹配"| D["navigate_to(expected)"]
    D --> E["检测当前场景并规划路径"]
```

`require_scene` 复用同一定向识别能力，但只验证调用方的前置条件，不执行导航。档案库扫描会在点击主界面入口前做这一次定向检查。

## 改动

- 使用 `SceneId` 变体的 `Discriminant` 建立场景注册索引，让带有具体分类的档案库子界面也能找到对应识别器。
- 让 `ensure_scene` 先尝试定向识别，匹配失败后进入导航。
- 新增严格验证前置场景的 `require_scene`，并用于档案库主界面的点击入口。
- 删除档案库任务启动时已由 `run_task` 满足的重复前置检查。

## 验证

- `cargo fmt --all -- --check`
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo xwin check --target x86_64-pc-windows-msvc --all-targets`
- `cargo xwin clippy --target x86_64-pc-windows-msvc --all-targets -- -D warnings`
- `cargo xwin build --target x86_64-pc-windows-msvc`

## Sourcery 摘要

通过将定向验证与完整场景导航分离，减少任务启动和存档扫描期间冗余的场景识别。

增强功能：
- 优化场景验证：仅检查预期的场景识别器，失败后再回退到完整导航。
- 添加严格且不进行导航的前置场景验证，并在进入存档子类别时使用该验证。
- 按 SceneId 变体为场景识别器建立索引，使参数化存档场景能够解析到其共享的识别器。

杂项：
- 移除存档扫描任务中冗余的启动前置检查，该检查已由任务执行处理。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

将针对性场景验证与完整导航分离，以减少任务启动和存档扫描期间冗余的场景识别。

增强功能：
- 通过仅检查预期的场景识别器来优化场景验证，失败后再回退到完整导航。
- 添加严格的非导航前置条件验证，并在进入存档类别时使用该验证。
- 按 SceneId 变体索引场景识别器，使参数化存档场景能够解析到其共享的识别器。

杂项：
- 移除存档扫描任务中冗余的启动场景检查，该检查已由任务执行处理。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

通过将针对性验证与完整场景导航分离，减少任务启动和归档扫描期间冗余的场景识别。

增强功能：
- 优化场景验证：仅检查预期的场景识别器，失败后再回退到完整导航。
- 添加严格的非导航前置条件验证，并在进入归档类别时使用该验证。
- 按 SceneId 变体索引场景识别器，以便参数化归档场景解析到其共享的识别器。

杂项：
- 移除归档扫描任务中冗余的启动前置条件检查，该检查已由任务执行处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Reduce redundant scene recognition during task startup and archive scanning by separating targeted validation from full scene navigation.

Enhancements:
- Optimize scene verification by checking only the expected scene recognizer before falling back to full navigation.
- Add strict non-navigating prerequisite validation and use it when entering archive categories.
- Index scene recognizers by SceneId variant so parameterized archive scenes resolve to their shared recognizer.

Chores:
- Remove the archive scan task's redundant startup prerequisite check, which is already handled by task execution.

</details>

</details>

</details>