### PR TITLE
fix(档案库): 移除固定条目数断言

### DIFF
--- a/src-tauri/src/types/archive_contract.rs
+++ b/src-tauri/src/types/archive_contract.rs
@@ -1,6 +1,6 @@
 //! `archive_contract.json` 的 Rust 类型定义（与前端 `src/types/archiveContract.ts` 对齐）。
 //!
-//! 该数据文件描述档案库全部 454 个逻辑条目（对应 prts.json allItems 按逻辑 id 归并）的
+//! 该数据文件描述档案库全部逻辑条目（对应 prts.json allItems 按逻辑 id 归并）的
 //! 获取方式，按 6 个分类分组。每条记录以 `acquisition.method` 为判别字段，对应不同的
 //! 获取途径与附加字段：
 //!
@@ -162,10 +162,8 @@ mod tests {
         let contract: ArchiveContract = serde_json::from_str(&text).expect("反序列化失败");
 
         assert_eq!(contract.version, 1);
-        // 6 个分类，共 454 个逻辑条目（对应 prts allItems 按逻辑 id 归并）
+        // 档案分类稳定为 6 类，可视为数据 schema 的一部分
         assert_eq!(contract.categories.len(), 6);
-        let total: usize = contract.categories.values().map(Vec::len).sum();
-        assert_eq!(total, 454);
 
         // 校验各获取方式必填字段一致
         for rows in contract.categories.values() {


### PR DESCRIPTION
> This message is generated by AI.

档案资源更新后，`archive_contract.json` 从 454 条增加到 487 条，但 Rust 测试仍断言固定条目数，导致数据自然增长时 Backend CI 失败。

相关失败日志：

- [main 发布提交的 Backend CI](https://github.com/Logical-Byte/open-endfield-assistant/actions/runs/33580739203/job/100094326447)
- [PR #40 的 Backend CI](https://github.com/Logical-Byte/open-endfield-assistant/actions/runs/33597610490/job/100144161162)
- [PR #40 合并后的 Backend CI](https://github.com/Logical-Byte/open-endfield-assistant/actions/runs/33597621993/job/100144208541)
- [v1.1.0 标签的 Backend CI](https://github.com/Logical-Byte/open-endfield-assistant/actions/runs/33610073189/job/100182938168)

条目总数会随游戏数据更新自然增长，固定数量无法作为稳定的数据约束。因此，本 PR 删除条目总数断言，并移除模块文档中的固定数量。

测试继续校验 JSON 能完整反序列化为 Rust 类型、契约版本、六个稳定档案分类以及各获取方式的必填字段。其中六个分类属于稳定的数据结构，可视为 schema 的一部分。

已通过后端测试、格式检查、Clippy，以及 Windows x86_64 交叉检查和构建。

## Summary by Sourcery

移除档案库的固定条目数约束，同时保留对稳定数据结构和字段完整性的校验。

Bug Fixes:
- 移除档案库测试中的固定条目总数断言，避免游戏数据自然增长导致后端 CI 失败。

Enhancements:
- 保留档案契约版本、六个稳定分类、完整反序列化及获取方式必填字段校验。

Documentation:
- 更新档案库模块文档，移除固定条目数量说明。

Tests:
- 调整档案契约测试，将条目总数约束替换为稳定分类数量校验。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

移除档案库的固定条目数约束，同时保留对稳定数据结构和字段完整性的校验。

Bug Fixes:
- 移除档案库测试中的固定条目总数断言，避免游戏数据自然增长导致后端 CI 失败。

Enhancements:
- 保留档案契约版本、六个稳定分类、完整反序列化及获取方式必填字段校验。

Documentation:
- 更新档案库模块文档，移除固定条目数量说明。

Tests:
- 调整档案契约测试，将条目总数约束替换为稳定分类数量校验。

</details>