### PR TITLE
feat(dev): 添加子模块初始化命令

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@
 ```bash
 git clone --recurse-submodules git@github.com:Logical-Byte/open-endfield-assistant.git
 # 如果已经克隆但没有子模块：
-git submodule update --init --recursive
+pnpm submodules:init
 ```
 
 ### 安装依赖

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "format:check": "prettier --check .",
     "check": "run-p typecheck lint format:check",
     "fix": "run-s typecheck lint:fix format",
+    "submodules:init": "git submodule update --init --recursive",
     "tauri": "tauri",
     "makedata": "jiti scripts/makeAllData.ts",
     "download:models": "jiti scripts/downloadModels.ts",


### PR DESCRIPTION
> This message is generated by AI.

开发者在已有 checkout 中初始化 `resources` 子模块时需要记住完整的 Git 命令。项目现在提供 `pnpm submodules:init`，并在贡献指南中使用该入口，降低本地开发环境准备的记忆成本。

验证：
- `./node_modules/.bin/prettier --check package.json CONTRIBUTING.md`
- `git submodule update --init --recursive`
- `git diff --check`
- `pnpm fix` 未执行成功：当前环境 Node.js v18.17.0，而 pnpm 11 要求 Node.js >=22.13。

## Sourcery 摘要

为现有检出版本初始化 Git 子模块提供便捷的 package-script 入口。

新功能：
- 添加用于初始化项目子模块的 pnpm 命令。

改进：
- 更新贡献者设置说明，以使用新的子模块初始化命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Provide a convenient package-script entry point for initializing Git submodules in existing checkouts.

New Features:
- Add a pnpm command for initializing project submodules.

Enhancements:
- Update contributor setup instructions to use the new submodule initialization command.

</details>