### PR TITLE
feat: 添加 OEM 下载源

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -16,6 +16,7 @@
       "allow": [
         { "url": "https://mirrorchyan.com/*" },
         { "url": "https://mirrorchyan.net/*" },
+        { "url": "https://oea.oem.re/*" },
         { "url": "https://api.github.com/*" }
       ]
     },

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -16,7 +16,7 @@
       "allow": [
         { "url": "https://mirrorchyan.com/*" },
         { "url": "https://mirrorchyan.net/*" },
-        { "url": "https://oea.oem.re/*" },
+        { "url": "https://package.oem.re/channels/oea/stable.json" },
         { "url": "https://api.github.com/*" }
       ]
     },

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -15,6 +15,7 @@ pub const CURRENT_MINOR_VERSION: u32 = 0;
 pub enum UpdateSource {
     #[default]
     Mirrorchyan,
+    Oem,
     Github,
 }
 

--- a/src/components/update/UpdatePopover.vue
+++ b/src/components/update/UpdatePopover.vue
@@ -305,7 +305,7 @@ function formatSpeed(bytesPerSecond: number): string {
                   <UInput
                     v-model="mirrorchyanCdk"
                     class="w-full"
-                    placeholder="未填写时使用 GitHub 下载"
+                    placeholder="未填写时使用 OEM 下载"
                     type="password"
                   />
                 </UFormField>

--- a/src/pages/settings.vue
+++ b/src/pages/settings.vue
@@ -262,7 +262,7 @@ onBeforeUnmount(() => {
               <UInput
                 v-model="mirrorchyanCdk"
                 class="w-56"
-                placeholder="未填写时使用 GitHub 下载"
+                placeholder="未填写时使用 OEM 下载"
                 type="password"
               />
               <ULink

--- a/src/pages/settings.vue
+++ b/src/pages/settings.vue
@@ -209,7 +209,7 @@ onBeforeUnmount(() => {
 
         <SettingsCard id="update" class="scroll-mt-8" icon="i-lucide-download" title="更新设置">
           <SettingsItem
-            description="选择从哪个源检查并下载新版本"
+            description="选择从哪个源下载新版本"
             icon="i-lucide-cloud-download"
             title="更新源"
           >

--- a/src/types/oeaConfig.ts
+++ b/src/types/oeaConfig.ts
@@ -1,5 +1,6 @@
 export enum UpdateSource {
   Mirrorchyan = 'mirrorchyan',
+  Oem = 'oem',
   Github = 'github',
 }
 

--- a/src/types/oem.ts
+++ b/src/types/oem.ts
@@ -1,0 +1,13 @@
+/** OEM 稳定版元数据响应。 */
+export interface OemStableManifest {
+  schemaVersion: 1;
+  channel: 'stable';
+  version: string;
+  tag: string;
+  filename: string;
+  key: string;
+  url: string;
+  size: number;
+  sha256: string;
+  publishedAt: string;
+}

--- a/src/types/update.ts
+++ b/src/types/update.ts
@@ -57,10 +57,10 @@ export enum UpdatePackageType {
 /** 已就绪的下载信息（URL + 校验信息，由「下载源决策」产出）。 */
 export interface PreparedUpdate {
   url: string;
-  /** 期望 sha256（GitHub 来源时来自 asset.digest；缺失则为 undefined） */
+  /** 期望 sha256（OEM 来源时来自 stable manifest，GitHub 来源时来自 asset.digest） */
   sha256?: string;
   fileSize?: number;
-  /** 建议文件名（GitHub 来源时为资产名；MirrorChyan 无此信息），服务端可能通过 Content-Disposition 覆盖实际文件名 */
+  /** 建议文件名（OEM / GitHub 来源时提供；MirrorChyan 无此信息），服务端可能通过 Content-Disposition 覆盖实际文件名 */
   filename?: string;
   source: UpdateSource;
   /** 更新包类型（MirrorChyan 按响应判定；GitHub 固定全量） */

--- a/src/utils/app/config.ts
+++ b/src/utils/app/config.ts
@@ -5,6 +5,7 @@ import { ref, watch } from 'vue';
 /** 更新源选项 */
 export const updateSourceItems = [
   { label: 'Mirror酱', value: UpdateSource.Mirrorchyan },
+  { label: 'OEM', value: UpdateSource.Oem },
   { label: 'GitHub', value: UpdateSource.Github },
 ];
 

--- a/src/utils/app/update.ts
+++ b/src/utils/app/update.ts
@@ -41,6 +41,8 @@ const CHECK_URL_BASES = [
 const GITHUB_OWNER = 'Logical-Byte';
 const GITHUB_REPO = 'open-endfield-assistant';
 const GITHUB_RELEASES_URL = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/releases`;
+/** OEM 稳定下载入口，会重定向到最新的 OEA 全量包。 */
+const OEM_DOWNLOAD_URL = 'https://oea.oem.re/latest';
 
 /**
  * 根据实际系统信息生成更新请求 UA（`OEA/<版本> (Windows NT <major.minor>; Win64; x64)`）。
@@ -212,7 +214,7 @@ interface DownloadResultPayload {
  * 执行一次检查更新（启动自动检查与设置页手动检查共用）。
  *
  * 检查固定请求 MirrorChyan（主备双站），无论「更新源」设置为何：更新源只决定
- * 后续下载从镜像还是 GitHub 拉取，不影响「是否可更新」的判定（见设计文档 v4）。
+ * 后续下载从 Mirror酱、OEM 还是 GitHub 拉取，不影响「是否可更新」的判定（见设计文档 v4）。
  */
 export async function checkUpdate(): Promise<void> {
   // 若当前正在检查更新，则忽略本次请求（避免重复请求）。
@@ -324,7 +326,7 @@ export async function startDownload(
 
   let unlisten: (() => void) | null = null;
   try {
-    // 准备下载信息：MirrorChyan 直连 / GitHub 匹配资产（含 digest）。
+    // 准备下载信息：MirrorChyan 直连 / OEM 稳定入口 / GitHub 匹配资产（含 digest）。
     const prepared = await prepareDownload(checkUpdateData);
     if (!prepared) {
       handleDownloadFailure(new Error('未获取到可用的下载链接'), '准备下载失败');
@@ -363,7 +365,7 @@ export async function startDownload(
 
     const { updateProxyMode, updateProxyUrl } = oeaConfig.value;
     const proxyMode =
-      prepared.source === UpdateSource.Github ? updateProxyMode : UpdateProxyMode.None;
+      prepared.source === UpdateSource.Mirrorchyan ? UpdateProxyMode.None : updateProxyMode;
     // 阻塞直到下载结束：Rust `download_update` 流式读完整响应体、写完盘并校验 sha256 后才返回，
     // 不会在开始下载后立即返回；期间进度由上面的 `download-progress` 事件上报。
     const result = await invoke<DownloadResultPayload>('download_update', {
@@ -630,8 +632,9 @@ function handleInstallFailure(error: unknown): void {
 
 /**
  * 下载源决策（设计文档 v4 §4）：
- * 1. 更新源为 MirrorChyan 且 CDK 已填写、MirrorChyan 给了 url → 用 MirrorChyan；
- * 2. 更新源为 GitHub，或 CDK 未填写（MirrorChyan 源回退）、或 MirrorChyan 未给 url
+ * 1. 更新源为 OEM → 使用 OEM 最新版本稳定入口；
+ * 2. 更新源为 MirrorChyan 且 CDK 已填写、MirrorChyan 给了 url → 用 MirrorChyan；
+ * 3. 更新源为 GitHub，或 CDK 未填写（MirrorChyan 源回退）、或 MirrorChyan 未给 url
  *    → 从 GitHub 匹配 tag 与资产（含 digest）。错误码场景已在 `checkUpdate` 抛错，不会走到这里。
  */
 async function prepareDownload(
@@ -639,6 +642,16 @@ async function prepareDownload(
 ): Promise<PreparedUpdate | null> {
   const cdk = mirrorchyanCdk.value.trim();
   const versionName = data.version_name;
+
+  if (oeaConfig.value.updateSource === UpdateSource.Oem) {
+    return {
+      url: OEM_DOWNLOAD_URL,
+      source: UpdateSource.Oem,
+      updateType: UpdatePackageType.Full,
+      versionName,
+      releaseNote: data.release_note,
+    };
+  }
 
   // 尊重「下载源」设置：只有选择 MirrorChyan 且 CDK 已填写时才走镜像；
   // 其余情况（源为 GitHub / CDK 未填写 / MirrorChyan 未给 url）一律回退 GitHub。

--- a/src/utils/app/update.ts
+++ b/src/utils/app/update.ts
@@ -214,7 +214,7 @@ interface DownloadResultPayload {
  * 执行一次检查更新（启动自动检查与设置页手动检查共用）。
  *
  * 检查固定请求 MirrorChyan（主备双站），无论「更新源」设置为何：更新源只决定
- * 后续下载从 Mirror酱、OEM 还是 GitHub 拉取，不影响「是否可更新」的判定（见设计文档 v4）。
+ * 后续下载从 Mirror酱、OEM 还是 GitHub 拉取，不影响「是否可更新」的判定。
  */
 export async function checkUpdate(): Promise<void> {
   // 若当前正在检查更新，则忽略本次请求（避免重复请求）。
@@ -631,11 +631,11 @@ function handleInstallFailure(error: unknown): void {
 }
 
 /**
- * 下载源决策（设计文档 v4 §4）：
- * 1. 更新源为 OEM → 使用 OEM 最新版本稳定入口；
+ * 下载源决策：
+ * 1. 明确选择 GitHub → 从 GitHub 匹配 tag 与资产（含 digest）；
  * 2. 更新源为 MirrorChyan 且 CDK 已填写、MirrorChyan 给了 url → 用 MirrorChyan；
- * 3. 更新源为 GitHub，或 CDK 未填写（MirrorChyan 源回退）、或 MirrorChyan 未给 url
- *    → 从 GitHub 匹配 tag 与资产（含 digest）。错误码场景已在 `checkUpdate` 抛错，不会走到这里。
+ * 3. 其他情况（选择 OEM、MirrorChyan 未填写 CDK 或未给 url）→ 预检 OEM 版本并使用 OEM 下载。
+ * OEM 预检失败或版本不一致时直接抛错，不回退到其他下载源。
  */
 async function prepareDownload(
   data: MirrorchyanResourcesLatestResponseData,
@@ -643,18 +643,6 @@ async function prepareDownload(
   const cdk = mirrorchyanCdk.value.trim();
   const versionName = data.version_name;
 
-  if (oeaConfig.value.updateSource === UpdateSource.Oem) {
-    return {
-      url: OEM_DOWNLOAD_URL,
-      source: UpdateSource.Oem,
-      updateType: UpdatePackageType.Full,
-      versionName,
-      releaseNote: data.release_note,
-    };
-  }
-
-  // 尊重「下载源」设置：只有选择 MirrorChyan 且 CDK 已填写时才走镜像；
-  // 其余情况（源为 GitHub / CDK 未填写 / MirrorChyan 未给 url）一律回退 GitHub。
   if (oeaConfig.value.updateSource === UpdateSource.Mirrorchyan && cdk && data.url) {
     return {
       url: data.url,
@@ -663,6 +651,17 @@ async function prepareDownload(
       source: UpdateSource.Mirrorchyan,
       updateType:
         data.update_type === 'incremental' ? UpdatePackageType.Incremental : UpdatePackageType.Full,
+      versionName,
+      releaseNote: data.release_note,
+    };
+  }
+
+  if (oeaConfig.value.updateSource !== UpdateSource.Github) {
+    const url = await resolveOemDownload(versionName);
+    return {
+      url,
+      source: UpdateSource.Oem,
+      updateType: UpdatePackageType.Full,
       versionName,
       releaseNote: data.release_note,
     };
@@ -682,6 +681,66 @@ async function prepareDownload(
     versionName,
     releaseNote: data.release_note,
   };
+}
+
+/**
+ * 预检 OEM 稳定入口并返回实际下载地址。
+ *
+ * OEM 入口必须先以不跟随重定向的请求读取版本标头；只有标头版本与 Mirror酱
+ * 本次检查返回的版本一致时，才允许继续下载。预检失败不会回退到其他源。
+ */
+async function resolveOemDownload(versionName: string): Promise<string> {
+  const init: RequestInit & ClientOptions = {
+    method: 'HEAD',
+    headers: {
+      'User-Agent': buildUpdateUserAgent(),
+    },
+    maxRedirections: 0,
+    ...(await buildProxyClientOptions()),
+  };
+
+  let response: Response;
+  try {
+    response = await fetch(OEM_DOWNLOAD_URL, init);
+  } catch (error) {
+    throw new Error(
+      `OEM 版本校验请求失败: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  if (response.status < 300 || response.status >= 400) {
+    throw new Error(`OEM 最新版本接口未返回重定向（HTTP ${response.status}），已中断下载`);
+  }
+
+  const oemVersion = response.headers.get('x-oem-relink-package-version')?.trim();
+  if (!oemVersion) {
+    throw new Error('OEM 最新版本接口缺少 x-oem-relink-package-version 标头，已中断下载');
+  }
+
+  const mirrorchyanVersion = versionName.trim().replace(/^v/i, '');
+  if (oemVersion !== mirrorchyanVersion) {
+    throw new Error(
+      `OEM 与 Mirror酱版本不一致（OEM: ${oemVersion}，Mirror酱: ${versionName}），已中断下载`,
+    );
+  }
+
+  const location = response.headers.get('location')?.trim();
+  if (!location) {
+    throw new Error('OEM 最新版本接口缺少 Location 标头，已中断下载');
+  }
+
+  let downloadUrl: URL;
+  try {
+    downloadUrl = new URL(location, OEM_DOWNLOAD_URL);
+  } catch (error) {
+    throw new Error(`OEM 重定向地址无效，已中断下载: ${String(error)}`);
+  }
+  if (downloadUrl.protocol !== 'https:') {
+    throw new Error('OEM 重定向地址不是 HTTPS，已中断下载');
+  }
+
+  logInfo(`OEM 版本校验通过: ${oemVersion}，下载地址: ${downloadUrl}`);
+  return downloadUrl.toString();
 }
 
 /**

--- a/src/utils/app/update.ts
+++ b/src/utils/app/update.ts
@@ -3,6 +3,7 @@ import {
   MirrorchyanResourcesLatestResponse,
   MirrorchyanResourcesLatestResponseData,
 } from '@/types/mirrorchyan';
+import { OemStableManifest } from '@/types/oem';
 import { UpdateProxyMode, UpdateSource } from '@/types/oeaConfig';
 import {
   ChangesJson,
@@ -41,8 +42,8 @@ const CHECK_URL_BASES = [
 const GITHUB_OWNER = 'Logical-Byte';
 const GITHUB_REPO = 'open-endfield-assistant';
 const GITHUB_RELEASES_URL = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/releases`;
-/** OEM 稳定下载入口，会重定向到最新的 OEA 全量包。 */
-const OEM_DOWNLOAD_URL = 'https://oea.oem.re/latest';
+/** OEM 稳定版元数据接口。 */
+const OEM_STABLE_MANIFEST_URL = 'https://package.oem.re/channels/oea/stable.json';
 
 /**
  * 根据实际系统信息生成更新请求 UA（`OEA/<版本> (Windows NT <major.minor>; Win64; x64)`）。
@@ -66,7 +67,7 @@ function buildCheckUpdateUrl(base: string): URL {
   url.searchParams.set('os', 'windows');
   url.searchParams.set('arch', 'amd64');
   const cdk = mirrorchyanCdk.value.trim();
-  if (cdk) {
+  if (oeaConfig.value.updateSource === UpdateSource.Mirrorchyan && cdk) {
     url.searchParams.set('cdk', cdk);
   }
   return url;
@@ -326,7 +327,7 @@ export async function startDownload(
 
   let unlisten: (() => void) | null = null;
   try {
-    // 准备下载信息：MirrorChyan 直连 / OEM 稳定入口 / GitHub 匹配资产（含 digest）。
+    // 准备下载信息。
     const prepared = await prepareDownload(checkUpdateData);
     if (!prepared) {
       handleDownloadFailure(new Error('未获取到可用的下载链接'), '准备下载失败');
@@ -634,8 +635,8 @@ function handleInstallFailure(error: unknown): void {
  * 下载源决策：
  * 1. 明确选择 GitHub → 从 GitHub 匹配 tag 与资产（含 digest）；
  * 2. 更新源为 MirrorChyan 且 CDK 已填写、MirrorChyan 给了 url → 用 MirrorChyan；
- * 3. 其他情况（选择 OEM、MirrorChyan 未填写 CDK 或未给 url）→ 预检 OEM 版本并使用 OEM 下载。
- * OEM 预检失败或版本不一致时直接抛错，不回退到其他下载源。
+ * 3. 其他情况（选择 OEM、MirrorChyan 未填写 CDK 或未给 url）→ 获取 OEM 稳定元数据并使用 OEM 下载。
+ * OEM 元数据请求失败或版本不一致时直接抛错，不回退到其他下载源。
  */
 async function prepareDownload(
   data: MirrorchyanResourcesLatestResponseData,
@@ -657,12 +658,15 @@ async function prepareDownload(
   }
 
   if (oeaConfig.value.updateSource !== UpdateSource.Github) {
-    const url = await resolveOemDownload(versionName);
+    const manifest = await resolveOemDownload(versionName);
     return {
-      url,
+      url: manifest.url,
+      sha256: manifest.sha256,
+      fileSize: manifest.size,
+      filename: manifest.filename,
       source: UpdateSource.Oem,
       updateType: UpdatePackageType.Full,
-      versionName,
+      versionName: manifest.tag,
       releaseNote: data.release_note,
     };
   }
@@ -684,63 +688,49 @@ async function prepareDownload(
 }
 
 /**
- * 预检 OEM 稳定入口并返回实际下载地址。
+ * 获取 OEM 稳定版元数据。
  *
- * OEM 入口必须先以不跟随重定向的请求读取版本标头；只有标头版本与 Mirror酱
- * 本次检查返回的版本一致时，才允许继续下载。预检失败不会回退到其他源。
+ * OEM 版本必须与 Mirror酱本次检查返回的版本一致，否则中断下载。
  */
-async function resolveOemDownload(versionName: string): Promise<string> {
+async function resolveOemDownload(versionName: string): Promise<OemStableManifest> {
   const init: RequestInit & ClientOptions = {
-    method: 'HEAD',
+    method: 'GET',
     headers: {
       'User-Agent': buildUpdateUserAgent(),
+      Accept: 'application/json',
     },
-    maxRedirections: 0,
     ...(await buildProxyClientOptions()),
   };
 
   let response: Response;
   try {
-    response = await fetch(OEM_DOWNLOAD_URL, init);
+    response = await fetch(OEM_STABLE_MANIFEST_URL, init);
   } catch (error) {
     throw new Error(
-      `OEM 版本校验请求失败: ${error instanceof Error ? error.message : String(error)}`,
+      `OEM 更新元数据请求失败: ${error instanceof Error ? error.message : String(error)}`,
     );
   }
 
-  if (response.status < 300 || response.status >= 400) {
-    throw new Error(`OEM 最新版本接口未返回重定向（HTTP ${response.status}），已中断下载`);
+  if (!response.ok) {
+    throw new Error(`OEM 更新元数据请求失败（HTTP ${response.status}），已中断下载`);
   }
 
-  const oemVersion = response.headers.get('x-oem-relink-package-version')?.trim();
-  if (!oemVersion) {
-    throw new Error('OEM 最新版本接口缺少 x-oem-relink-package-version 标头，已中断下载');
+  let manifest: OemStableManifest;
+  try {
+    manifest = await response.json();
+  } catch (error) {
+    throw new Error(`OEM 更新元数据不是有效 JSON，已中断下载: ${String(error)}`);
   }
 
   const mirrorchyanVersion = versionName.trim().replace(/^v/i, '');
-  if (oemVersion !== mirrorchyanVersion) {
+  if (manifest.version !== mirrorchyanVersion) {
     throw new Error(
-      `OEM 与 Mirror酱版本不一致（OEM: ${oemVersion}，Mirror酱: ${versionName}），已中断下载`,
+      `OEM 与 Mirror酱版本不一致（OEM: ${manifest.tag}，Mirror酱: ${versionName}），已中断下载`,
     );
   }
 
-  const location = response.headers.get('location')?.trim();
-  if (!location) {
-    throw new Error('OEM 最新版本接口缺少 Location 标头，已中断下载');
-  }
-
-  let downloadUrl: URL;
-  try {
-    downloadUrl = new URL(location, OEM_DOWNLOAD_URL);
-  } catch (error) {
-    throw new Error(`OEM 重定向地址无效，已中断下载: ${String(error)}`);
-  }
-  if (downloadUrl.protocol !== 'https:') {
-    throw new Error('OEM 重定向地址不是 HTTPS，已中断下载');
-  }
-
-  logInfo(`OEM 版本校验通过: ${oemVersion}，下载地址: ${downloadUrl}`);
-  return downloadUrl.toString();
+  logInfo(`OEM 与 Mirror酱版本一致: ${manifest.tag}，下载地址: ${manifest.url}`);
+  return manifest;
 }
 
 /**


### PR DESCRIPTION
## Sourcery 摘要

添加 OEM 下载源并将其集成到应用更新源选择与下载流程中。

新功能：
- 新增 OEM 更新源选项，支持通过稳定入口下载最新 OEA 全量安装包。

改进：
- 调整更新源下载代理策略，并更新更新设置说明以反映 OEM 下载支持。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

在更新源选择和下载流程中添加 OEM 支持，并进行版本验证以及适用于不同来源的代理处理。

新功能：
- 添加 OEM 作为更新源，并提供稳定的入口以下载最新的完整 OEA 软件包。

改进：
- 通过所选来源执行下载，根据更新检查结果验证 OEM 版本，并将代理设置一致地应用于非 Mirror酱下载。
- 更新更新源标签和设置说明，以反映对 OEM 下载的支持。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

在更新源选择和下载流程中增加 OEM 支持。

新功能：
- 将 OEM 添加为更新源，并提供用于下载最新完整 OEA 软件包的稳定入口。

增强功能：
- 根据所选来源路由下载，依据更新检查结果验证 OEM 版本，并将代理设置一致地应用于非 Mirror酱下载。
- 更新更新源标签和设置说明，以体现对 OEM 下载的支持。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

为更新源选择和下载工作流添加 OEM 支持。

新功能：
- 添加 OEM 作为更新源，并支持稳定元数据和完整软件包下载。

错误修复：
- 当 OEM 元数据不可用，或其版本与检查到的更新不匹配时，阻止继续下载。

增强功能：
- 根据所选来源分配更新下载，并在 Mirror酱下载之外统一应用代理设置。

文档：
- 更新更新源标签、描述和下载指南，以反映 OEM 支持。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add OEM support to the update-source selection and download workflow.

New Features:
- Add OEM as an update source with stable metadata and full-package download support.

Bug Fixes:
- Prevent downloads from proceeding when OEM metadata is unavailable or its version does not match the checked update.

Enhancements:
- Route update downloads according to the selected source and apply proxy settings consistently outside Mirror酱 downloads.

Documentation:
- Update update-source labels, descriptions, and download guidance to reflect OEM support.

</details>

</details>

</details>

</details>