### PR TITLE
refactor(backend:scene): 分离场景截图与识别

### DIFF
--- a/src-tauri/src/scene/mod.rs
+++ b/src-tauri/src/scene/mod.rs
@@ -12,6 +12,7 @@ mod scene_detector;
 pub mod scene_manager;
 mod scenes;
 
+pub use crate::session::RecognitionContext;
 pub use model::{Scene, SceneAction, SceneId, SceneTransition, 档案库SubSceneId};
 pub use scene_manager::SceneManager;
 pub use scenes::{Scene未知, archive, overworld, terminal};

--- a/src-tauri/src/scene/model/scene_trait.rs
+++ b/src-tauri/src/scene/model/scene_trait.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Result;
 
-use crate::session::Session;
+use crate::session::{RecognitionContext, Session};
 
 use super::{SceneAction, SceneId};
 
@@ -21,15 +21,15 @@ pub trait Scene: Send + Sync {
     /// 返回场景名称（用于日志）。
     fn name(&self) -> &'static str;
 
-    /// 尝试识别当前截图是否为此场景。
+    /// 尝试识别当前识别帧是否为此场景。
     ///
     /// # 参数
-    /// - `session`: 会话上下文（从中获取截图等）
+    /// - `context`: 同一识别帧上的受限识别能力
     ///
     /// # 返回
     /// - `Ok(Some(scene_id))`: 识别成功，返回确切的场景 ID（子界面可能需要返回更具体的 ID）
     /// - `Ok(None)`: 不是此场景
-    fn try_recognize(&self, session: &mut Session) -> Result<Option<SceneId>>;
+    fn try_recognize(&self, context: &mut RecognitionContext<'_>) -> Result<Option<SceneId>>;
 
     /// 返回从此场景可以跳转到的目标场景及跳转方式。
     ///

--- a/src-tauri/src/scene/scene_detector.rs
+++ b/src-tauri/src/scene/scene_detector.rs
@@ -36,14 +36,13 @@ impl SceneDetector {
     }
 
     pub(super) fn detect_current_scene(&self, session: &mut Session) -> Result<SceneId> {
-        // Preserve the detection contract: capture failures must abort even when
-        // the fallback unknown scene would otherwise match.
-        session.screencap_for_recognition()?;
+        let frame = session.screencap_for_recognition()?;
+        let mut context = session.recognition_context(&frame);
 
         for scene in &self.scenes {
             // 模板或图像错误必须终止任务，不能降级成「未知场景」。
             let id = scene
-                .try_recognize(session)
+                .try_recognize(&mut context)
                 .with_context(|| format!("场景识别出错 ({})", scene.name()))?;
             if let Some(id) = id {
                 debug!("场景检测: 当前处于 {:?}", id);
@@ -68,8 +67,10 @@ impl SceneDetector {
         let scene = self
             .get_registered_scene(expected)
             .ok_or_else(|| anyhow::anyhow!("未注册的场景: {:?}", expected))?;
+        let frame = session.screencap_for_recognition()?;
+        let mut context = session.recognition_context(&frame);
         let recognized = scene
-            .try_recognize(session)
+            .try_recognize(&mut context)
             .with_context(|| format!("场景识别出错 ({})", scene.name()))?;
         Ok(recognized == Some(expected))
     }

--- a/src-tauri/src/scene/scenes/archive.rs
+++ b/src-tauri/src/scene/scenes/archive.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 
 use super::super::model::{Scene, SceneAction, SceneId, SceneTransition, 档案库SubSceneId};
 use super::TEMPLATE_MATCH_THRESHOLD;
-use crate::session::Session;
+use crate::session::RecognitionContext;
 use crate::utils::region::Region2D;
 
 // ============================================================================
@@ -60,13 +60,10 @@ impl Scene for Scene档案详情页面 {
         "档案详情页面"
     }
 
-    fn try_recognize(&self, session: &mut Session) -> Result<Option<SceneId>> {
-        let screenshot = session.screencap_for_recognition()?;
-
+    fn try_recognize(&self, context: &mut RecognitionContext<'_>) -> Result<Option<SceneId>> {
         // 必须同时满足两个条件：有档案详情装饰 且 有关闭按钮
-        let has_decoration = session
+        let has_decoration = context
             .find_template_in_roi(
-                &screenshot,
                 "情报档案库/档案详情装饰.png",
                 ROI_档案详情装饰,
                 TEMPLATE_MATCH_THRESHOLD,
@@ -76,9 +73,8 @@ impl Scene for Scene档案详情页面 {
             return Ok(None);
         }
 
-        let has_close = session
+        let has_close = context
             .find_template_in_roi(
-                &screenshot,
                 "情报档案库/档案详情关闭.png",
                 ROI_右上角关闭,
                 TEMPLATE_MATCH_THRESHOLD,
@@ -132,13 +128,10 @@ impl Scene for Scene档案库子界面 {
         "档案库子界面"
     }
 
-    fn try_recognize(&self, session: &mut Session) -> Result<Option<SceneId>> {
-        let screenshot = session.screencap_for_recognition()?;
-
+    fn try_recognize(&self, context: &mut RecognitionContext<'_>) -> Result<Option<SceneId>> {
         // 1. 检查标题
-        let has_title = session
+        let has_title = context
             .find_template_in_roi(
-                &screenshot,
                 "情报档案库/情报档案库标题.png",
                 ROI_档案库标题,
                 TEMPLATE_MATCH_THRESHOLD,
@@ -149,9 +142,8 @@ impl Scene for Scene档案库子界面 {
         }
 
         // 2. 检查子界面关闭按钮（区别于主界面的关闭按钮）
-        let has_close = session
+        let has_close = context
             .find_template_in_roi(
-                &screenshot,
                 "情报档案库/档案库子界面关闭.png",
                 ROI_右上角关闭,
                 TEMPLATE_MATCH_THRESHOLD,
@@ -162,12 +154,12 @@ impl Scene for Scene档案库子界面 {
         }
 
         // 3. 判断属于哪个分类（通过水印）
-        let Some(category) = self.detect_category(session, &screenshot)? else {
+        let Some(category) = self.detect_category(context)? else {
             return Ok(None);
         };
 
         // 4. 判断具体是哪个子界面（通过 tab 颜色 ROI）
-        let sub_scene = self.detect_sub_scene(session, category)?;
+        let sub_scene = self.detect_sub_scene(context, category)?;
         Ok(Some(SceneId::档案库子界面(sub_scene)))
     }
 
@@ -200,8 +192,7 @@ impl Scene档案库子界面 {
     /// 通过水印判断属于哪个分类（音像存档 / 见闻辑录 / 中枢档案）。
     fn detect_category(
         &self,
-        session: &mut Session,
-        screenshot: &image::RgbaImage,
+        context: &mut RecognitionContext<'_>,
     ) -> Result<Option<&'static str>> {
         let categories = [
             ("音像存档", "情报档案库/音像存档水印.png"),
@@ -210,8 +201,8 @@ impl Scene档案库子界面 {
         ];
 
         for (name, template) in &categories {
-            if session
-                .find_template_in_roi(screenshot, template, ROI_水印, TEMPLATE_MATCH_THRESHOLD)?
+            if context
+                .find_template_in_roi(template, ROI_水印, TEMPLATE_MATCH_THRESHOLD)?
                 .is_some()
             {
                 return Ok(Some(name));
@@ -227,15 +218,12 @@ impl Scene档案库子界面 {
     /// 深色（灰度 < 阈值）表示当前选中该 tab。
     fn detect_sub_scene(
         &self,
-        session: &mut Session,
+        context: &RecognitionContext<'_>,
         category: &str,
     ) -> Result<档案库SubSceneId> {
-        // 需要重新截图（前面的模板匹配可能消耗了原图）
-        let screenshot = session.screencap_for_recognition()?;
-
-        let tab0_dark = session.is_roi_dark_ltwh(&screenshot, 180, 120, 60, 36, DARK_THRESHOLD);
-        let tab1_dark = session.is_roi_dark_ltwh(&screenshot, 180, 184, 60, 36, DARK_THRESHOLD);
-        let tab2_dark = session.is_roi_dark_ltwh(&screenshot, 180, 248, 60, 36, DARK_THRESHOLD);
+        let tab0_dark = context.is_roi_dark_ltwh(180, 120, 60, 36, DARK_THRESHOLD);
+        let tab1_dark = context.is_roi_dark_ltwh(180, 184, 60, 36, DARK_THRESHOLD);
+        let tab2_dark = context.is_roi_dark_ltwh(180, 248, 60, 36, DARK_THRESHOLD);
 
         match category {
             "音像存档" => {
@@ -290,13 +278,10 @@ impl Scene for Scene档案库主界面 {
         "档案库主界面"
     }
 
-    fn try_recognize(&self, session: &mut Session) -> Result<Option<SceneId>> {
-        let screenshot = session.screencap_for_recognition()?;
-
+    fn try_recognize(&self, context: &mut RecognitionContext<'_>) -> Result<Option<SceneId>> {
         // 1. 检查标题
-        let has_title = session
+        let has_title = context
             .find_template_in_roi(
-                &screenshot,
                 "情报档案库/情报档案库标题.png",
                 ROI_档案库标题,
                 TEMPLATE_MATCH_THRESHOLD,
@@ -307,9 +292,8 @@ impl Scene for Scene档案库主界面 {
         }
 
         // 2. 检查主界面关闭按钮（与子界面关闭按钮不同）
-        let has_main_close = session
+        let has_main_close = context
             .find_template_in_roi(
-                &screenshot,
                 "情报档案库/档案库主界面关闭.png",
                 ROI_右上角关闭,
                 TEMPLATE_MATCH_THRESHOLD,
@@ -321,25 +305,22 @@ impl Scene for Scene档案库主界面 {
         }
 
         // 3. 确认至少有一个入口按钮存在
-        let has_any_entry = session
+        let has_any_entry = context
             .find_template_in_roi(
-                &screenshot,
                 "情报档案库/音像存档.png",
                 ROI_音像存档按钮,
                 TEMPLATE_MATCH_THRESHOLD,
             )?
             .is_some()
-            || session
+            || context
                 .find_template_in_roi(
-                    &screenshot,
                     "情报档案库/见闻辑录.png",
                     ROI_见闻辑录按钮,
                     TEMPLATE_MATCH_THRESHOLD,
                 )?
                 .is_some()
-            || session
+            || context
                 .find_template_in_roi(
-                    &screenshot,
                     "情报档案库/中枢档案.png",
                     ROI_中枢档案按钮,
                     TEMPLATE_MATCH_THRESHOLD,

--- a/src-tauri/src/scene/scenes/overworld.rs
+++ b/src-tauri/src/scene/scenes/overworld.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 
 use super::super::model::{Scene, SceneAction, SceneId, SceneTransition};
 use super::TEMPLATE_MATCH_THRESHOLD;
-use crate::session::Session;
+use crate::session::RecognitionContext;
 use crate::utils::region::Region2D;
 
 /// 协议终端按钮 ROI (1180, 0, 1280, 100)
@@ -24,16 +24,9 @@ impl Scene for Scene大世界 {
         "大世界"
     }
 
-    fn try_recognize(&self, session: &mut Session) -> Result<Option<SceneId>> {
-        let screenshot = session.screencap_for_recognition()?;
-
-        let found = session
-            .find_template_in_roi(
-                &screenshot,
-                "协议终端.png",
-                ROI_协议终端按钮,
-                TEMPLATE_MATCH_THRESHOLD,
-            )?
+    fn try_recognize(&self, context: &mut RecognitionContext<'_>) -> Result<Option<SceneId>> {
+        let found = context
+            .find_template_in_roi("协议终端.png", ROI_协议终端按钮, TEMPLATE_MATCH_THRESHOLD)?
             .is_some();
 
         Ok(if found {

--- a/src-tauri/src/scene/scenes/terminal.rs
+++ b/src-tauri/src/scene/scenes/terminal.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 
 use super::super::model::{Scene, SceneAction, SceneId, SceneTransition};
 use super::TEMPLATE_MATCH_THRESHOLD;
-use crate::session::Session;
+use crate::session::RecognitionContext;
 use crate::utils::region::Region2D;
 
 /// 档案库按钮 ROI (971, 108, 1280, 700)
@@ -24,16 +24,9 @@ impl Scene for Scene协议终端 {
         "协议终端"
     }
 
-    fn try_recognize(&self, session: &mut Session) -> Result<Option<SceneId>> {
-        let screenshot = session.screencap_for_recognition()?;
-
-        let found = session
-            .find_template_in_roi(
-                &screenshot,
-                "档案库.png",
-                ROI_档案库按钮,
-                TEMPLATE_MATCH_THRESHOLD,
-            )?
+    fn try_recognize(&self, context: &mut RecognitionContext<'_>) -> Result<Option<SceneId>> {
+        let found = context
+            .find_template_in_roi("档案库.png", ROI_档案库按钮, TEMPLATE_MATCH_THRESHOLD)?
             .is_some();
 
         Ok(if found {

--- a/src-tauri/src/scene/scenes/unknown.rs
+++ b/src-tauri/src/scene/scenes/unknown.rs
@@ -5,7 +5,7 @@ use std::sync::LazyLock;
 use anyhow::Result;
 
 use super::super::model::{Scene, SceneId, SceneTransition};
-use crate::session::Session;
+use crate::session::RecognitionContext;
 
 /// 未知界面（兜底）：所有场景都无法识别时使用；不允许从此场景导航。
 pub struct Scene未知;
@@ -19,7 +19,7 @@ impl Scene for Scene未知 {
         "未知界面"
     }
 
-    fn try_recognize(&self, _session: &mut Session) -> Result<Option<SceneId>> {
+    fn try_recognize(&self, _context: &mut RecognitionContext<'_>) -> Result<Option<SceneId>> {
         // 未知场景总是返回自身（作为兜底）
         Ok(Some(SceneId::未知))
     }

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -11,6 +11,10 @@
 //!
 //! 会话贯穿一次游戏操作（扫描档案库任务），由调用方以 `&mut` 串行使用。
 
+mod recognition_context;
+
+pub use recognition_context::RecognitionContext;
+
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -113,6 +117,11 @@ impl Session {
         Ok(self.resolution.scale_screenshot_to_base(&raw))
     }
 
+    /// 为一个固定识别帧借用会话的识别基础设施。
+    pub fn recognition_context<'a>(&'a mut self, frame: &'a RgbaImage) -> RecognitionContext<'a> {
+        RecognitionContext::new(frame, &mut self.templates)
+    }
+
     // ========== 输入（统一 720p → 实际分辨率缩放） ==========
 
     /// 点击 720p 基准坐标点（自动缩放），点击后鼠标回到窗口中心，
@@ -163,16 +172,8 @@ impl Session {
         roi: Region2D<u32>,
         threshold: f32,
     ) -> Result<Option<MatchResult>> {
-        // 直接传 RgbaImage 引用：泛型接口内部灰度化，无需克隆 / 颜色转换。
-        // 错误（如模板加载失败）用 ? 向上传播，交由上层记录日志。
-        let m = self
-            .templates
-            .match_template_in_region(screenshot, template_name, Some(roi))?;
-        if m.score >= threshold {
-            Ok(Some(m))
-        } else {
-            Ok(None)
-        }
+        self.recognition_context(screenshot)
+            .find_template_in_roi(template_name, roi, threshold)
     }
 
     /// 在 720p 截图指定 ROI 内搜索模板，找到后点击其中心（自动缩放）。
@@ -221,33 +222,6 @@ impl Session {
         } else {
             Ok("".into())
         }
-    }
-
-    // ========== 颜色判断 ==========
-
-    /// 判断 720p 截图 ROI（ltwh）区域平均灰度是否低于阈值（即深色 / 选中态）。
-    pub fn is_roi_dark_ltwh(
-        &self,
-        screenshot: &RgbaImage,
-        x: u32,
-        y: u32,
-        w: u32,
-        h: u32,
-        threshold: u8,
-    ) -> bool {
-        self.is_roi_dark(screenshot, Region2D::from_ltwh(x, y, w, h), threshold)
-    }
-
-    /// 判断 720p 截图 ROI 区域平均灰度是否低于阈值。
-    fn is_roi_dark(&self, screenshot: &RgbaImage, roi: Region2D<u32>, threshold: u8) -> bool {
-        let cropped = imageops::crop_imm(screenshot, roi.x0(), roi.y0(), roi.width(), roi.height());
-        let gray = imageops::grayscale(&cropped.to_image());
-        let total: u64 = gray.pixels().map(|p| p.0[0] as u64).sum();
-        let pixel_count = (roi.width() * roi.height()) as u64;
-        if pixel_count == 0 {
-            return false;
-        }
-        ((total / pixel_count) as u8) < threshold
     }
 
     // ========== 截图器 / 输入器切换（扩展点） ==========

--- a/src-tauri/src/session/recognition_context.rs
+++ b/src-tauri/src/session/recognition_context.rs
@@ -1,0 +1,59 @@
+//! 在单个固定识别帧上提供场景识别能力。
+
+use anyhow::Result;
+use image::{RgbaImage, imageops};
+
+use crate::{
+    template_matching::{MatchResult, TemplateManager},
+    utils::region::Region2D,
+};
+
+/// [`Session`](super::Session) 所有识别基础设施的受限视图。
+///
+/// 识别帧在上下文存续期内保持不变。模板仍按需加载，并可能修改会话所有的模板缓存。
+pub struct RecognitionContext<'a> {
+    frame: &'a RgbaImage,
+    templates: &'a mut TemplateManager,
+}
+
+impl<'a> RecognitionContext<'a> {
+    pub(super) fn new(frame: &'a RgbaImage, templates: &'a mut TemplateManager) -> Self {
+        Self { frame, templates }
+    }
+
+    /// 返回正在分类的 1280×720 识别帧。
+    pub fn frame(&self) -> &RgbaImage {
+        self.frame
+    }
+
+    /// 在识别帧的指定区域内搜索模板。
+    pub fn find_template_in_roi(
+        &mut self,
+        template_name: &str,
+        roi: Region2D<u32>,
+        threshold: f32,
+    ) -> Result<Option<MatchResult>> {
+        let result =
+            self.templates
+                .match_template_in_region(self.frame, template_name, Some(roi))?;
+        if result.score >= threshold {
+            Ok(Some(result))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// 判断矩形区域的平均灰度是否低于 `threshold`。
+    pub fn is_roi_dark_ltwh(&self, x: u32, y: u32, width: u32, height: u32, threshold: u8) -> bool {
+        let roi = Region2D::from_ltwh(x, y, width, height);
+        let cropped = imageops::crop_imm(self.frame, roi.x0(), roi.y0(), roi.width(), roi.height());
+        let gray = imageops::grayscale(&cropped.to_image());
+        let pixel_count = (roi.width() * roi.height()) as u64;
+        if pixel_count == 0 {
+            return false;
+        }
+
+        let total: u64 = gray.pixels().map(|pixel| pixel.0[0] as u64).sum();
+        ((total / pixel_count) as u8) < threshold
+    }
+}


### PR DESCRIPTION
> This is generated by AI. Do not reply.

`Scene::try_recognize` 原本接收整个 `Session`，每个场景识别器都自行截图后再判断画面内容。这使「获取当前画面」的副作用与「识别该画面属于哪个场景」的判断耦合在同一接口中。完整场景检测还会重复截图，各识别器可能观察到不同时刻的画面。

本 PR 将识别帧的获取上移到 `SceneDetector`。每次检测只截取并归一化一帧，然后构建受限的 `RecognitionContext`，依次交给所有场景识别器分类。

```diff
 detect_current_scene
-  try_recognize(&mut Session)
-    screencap_for_recognition()
+  frame = screencap_for_recognition()
+  context = RecognitionContext(frame, template_cache)
+  try_recognize(&mut context)
```

`RecognitionContext` 只暴露当前识别帧、带阈值的模板匹配和 ROI 深色判断。场景实现无法再发起截图、输入或 OCR 操作。模板仍由 `Session` 所有并按需加载，因此原有模板缓存行为和错误传播保持不变。

档案库子界面的 tab 颜色判断也改为使用同一识别帧，并删除了原来「模板匹配可能消耗原图」而重新截图的路径。`Session::find_template_in_roi` 继续保留给场景外的任务代码，内部委托给新上下文。

## Sourcery 总结

将场景截图获取与识别解耦，使每次检测都能通过受限的识别能力，对单个一致的帧进行分类。

改进：
- 通过引入围绕每次检测的单个标准化帧构建的受限识别上下文，将场景帧捕获与场景分类分离。
- 更新所有场景识别器和归档子场景检测，使其共享同一帧，同时保留由会话负责的模板缓存和模板查找兼容性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Decouple scene screenshot acquisition from recognition so each detection classifies a single consistent frame through restricted recognition capabilities.

Enhancements:
- Separate scene frame capture from scene classification by introducing a restricted recognition context built around one normalized frame per detection.
- Update all scene recognizers and archive sub-scene detection to share the same frame while retaining session-owned template caching and template lookup compatibility.

</details>