### PR TITLE
refactor(backend:region): 统一矩形区域表示与坐标维护

### DIFF
--- a/src-tauri/src/resolution/mod.rs
+++ b/src-tauri/src/resolution/mod.rs
@@ -59,17 +59,6 @@ impl GameResolution {
         (self.scale_x(x), self.scale_y(y))
     }
 
-    /// 将 720p 基准坐标系中的矩形区域缩放到当前分辨率。
-    /// 返回 (scaled_left, scaled_top, scaled_right, scaled_bottom)。
-    pub fn scale_ltrb(&self, left: u32, top: u32, right: u32, bottom: u32) -> (u32, u32, u32, u32) {
-        (
-            self.scale_x(left),
-            self.scale_y(top),
-            self.scale_x(right),
-            self.scale_y(bottom),
-        )
-    }
-
     /// 将截图缩放到 720p 基准分辨率，用于识别。
     /// 如果已经是基准分辨率则直接返回原图。
     pub fn scale_screenshot_to_base(&self, image: &RgbaImage) -> RgbaImage {

--- a/src-tauri/src/scene/model/mod.rs
+++ b/src-tauri/src/scene/model/mod.rs
@@ -5,5 +5,6 @@ mod scene_id;
 mod scene_trait;
 
 pub use scene_action::SceneAction;
+pub(crate) use scene_action::TAB_ROIS;
 pub use scene_id::{SceneId, 档案库SubSceneId};
 pub use scene_trait::{Scene, SceneTransition};

--- a/src-tauri/src/scene/model/scene_action.rs
+++ b/src-tauri/src/scene/model/scene_action.rs
@@ -3,7 +3,16 @@
 use anyhow::Result;
 use image::RgbaImage;
 
-use crate::{session::Session, utils::region::Region2D};
+use crate::{
+    session::Session,
+    utils::region::{Region2D, ltwh},
+};
+
+pub(crate) const TAB_ROIS: [Region2D<u32>; 3] = [
+    ltwh!(180, 120, 60, 36),
+    ltwh!(180, 184, 60, 36),
+    ltwh!(180, 248, 60, 36),
+];
 
 /// 从一个场景跳转到另一个场景的具体动作。
 pub enum SceneAction {
@@ -48,17 +57,11 @@ impl SceneAction {
                 session.click_at_720p(*x, *y)?;
             }
             SceneAction::ClickSubTab { roi_index } => {
-                // 颜色 ROI 的 ltwh 坐标：从上到下分别是 (180, 120, 60, 36)、
-                // (180, 184, 60, 36)、(180, 248, 60, 36)
-                const TAB_ROIS: [(u32, u32, u32, u32); 3] =
-                    [(180, 120, 60, 36), (180, 184, 60, 36), (180, 248, 60, 36)];
-                let (x, y, w, h) = TAB_ROIS
+                let roi = TAB_ROIS
                     .get(*roi_index)
                     .ok_or_else(|| anyhow::anyhow!("无效的 ROI 索引: {roi_index}"))?;
-                // 点击 ROI 中心
-                let cx = x + w / 2;
-                let cy = y + h / 2;
-                session.click_at_720p(cx, cy)?;
+                let center = roi.center();
+                session.click_at_720p(center.x, center.y)?;
             }
             SceneAction::PressKey { vk_code } => {
                 session.press_key(*vk_code)?;

--- a/src-tauri/src/scene/scenes/archive.rs
+++ b/src-tauri/src/scene/scenes/archive.rs
@@ -10,32 +10,32 @@ use anyhow::Result;
 use super::super::model::{Scene, SceneAction, SceneId, SceneTransition, 档案库SubSceneId};
 use super::TEMPLATE_MATCH_THRESHOLD;
 use crate::session::RecognitionContext;
-use crate::utils::region::Region2D;
+use crate::utils::region::{Region2D, ltrb, ltwh};
 
 // ============================================================================
 // 常用 ROI 和阈值常量（720p 基准）
 // ============================================================================
 
 /// 档案库标题 ROI
-const ROI_档案库标题: Region2D<u32> = Region2D::from_ltrb(0, 0, 162, 76);
+const ROI_档案库标题: Region2D<u32> = ltrb!(0, 0, 162, 76);
 
 /// 右上角关闭按钮 ROI (1180, 0, 1280, 100)
-const ROI_右上角关闭: Region2D<u32> = Region2D::from_ltrb(1180, 0, 1280, 100);
+const ROI_右上角关闭: Region2D<u32> = ltrb!(1180, 0, 1280, 100);
 
 /// 水印 ROI (52, 482, 189, 618)
-const ROI_水印: Region2D<u32> = Region2D::from_ltrb(52, 482, 189, 618);
+const ROI_水印: Region2D<u32> = ltrb!(52, 482, 189, 618);
 
 /// 档案详情装饰 ROI (356, 34, 496, 77)
-const ROI_档案详情装饰: Region2D<u32> = Region2D::from_ltrb(356, 34, 496, 77);
+const ROI_档案详情装饰: Region2D<u32> = ltrb!(356, 34, 496, 77);
 
 /// 音像存档按钮 ROI (692, 371, 959, 601)
-const ROI_音像存档按钮: Region2D<u32> = Region2D::from_ltrb(692, 371, 959, 601);
+const ROI_音像存档按钮: Region2D<u32> = ltrb!(692, 371, 959, 601);
 
 /// 见闻辑录按钮 ROI (957, 135, 1221, 371)
-const ROI_见闻辑录按钮: Region2D<u32> = Region2D::from_ltrb(957, 135, 1221, 371);
+const ROI_见闻辑录按钮: Region2D<u32> = ltrb!(957, 135, 1221, 371);
 
 /// 中枢档案按钮 ROI (958, 369, 1220, 601)
-const ROI_中枢档案按钮: Region2D<u32> = Region2D::from_ltrb(958, 369, 1220, 601);
+const ROI_中枢档案按钮: Region2D<u32> = ltrb!(958, 369, 1220, 601);
 
 /// 颜色判断阈值：灰度 < 128 视为深色（选中状态）
 const DARK_THRESHOLD: u8 = 128;
@@ -221,9 +221,9 @@ impl Scene档案库子界面 {
         context: &RecognitionContext<'_>,
         category: &str,
     ) -> Result<档案库SubSceneId> {
-        let tab0_dark = context.is_roi_dark_ltwh(180, 120, 60, 36, DARK_THRESHOLD);
-        let tab1_dark = context.is_roi_dark_ltwh(180, 184, 60, 36, DARK_THRESHOLD);
-        let tab2_dark = context.is_roi_dark_ltwh(180, 248, 60, 36, DARK_THRESHOLD);
+        let tab0_dark = context.is_roi_dark(ltwh!(180, 120, 60, 36), DARK_THRESHOLD);
+        let tab1_dark = context.is_roi_dark(ltwh!(180, 184, 60, 36), DARK_THRESHOLD);
+        let tab2_dark = context.is_roi_dark(ltwh!(180, 248, 60, 36), DARK_THRESHOLD);
 
         match category {
             "音像存档" => {

--- a/src-tauri/src/scene/scenes/archive.rs
+++ b/src-tauri/src/scene/scenes/archive.rs
@@ -7,10 +7,12 @@ use std::sync::LazyLock;
 
 use anyhow::Result;
 
-use super::super::model::{Scene, SceneAction, SceneId, SceneTransition, 档案库SubSceneId};
+use super::super::model::{
+    Scene, SceneAction, SceneId, SceneTransition, TAB_ROIS, 档案库SubSceneId,
+};
 use super::TEMPLATE_MATCH_THRESHOLD;
 use crate::session::RecognitionContext;
-use crate::utils::region::{Region2D, ltrb, ltwh};
+use crate::utils::region::{Region2D, ltrb};
 
 // ============================================================================
 // 常用 ROI 和阈值常量（720p 基准）
@@ -29,13 +31,13 @@ const ROI_水印: Region2D<u32> = ltrb!(52, 482, 189, 618);
 const ROI_档案详情装饰: Region2D<u32> = ltrb!(356, 34, 496, 77);
 
 /// 音像存档按钮 ROI (692, 371, 959, 601)
-const ROI_音像存档按钮: Region2D<u32> = ltrb!(692, 371, 959, 601);
+pub(crate) const ROI_音像存档按钮: Region2D<u32> = ltrb!(692, 371, 959, 601);
 
 /// 见闻辑录按钮 ROI (957, 135, 1221, 371)
-const ROI_见闻辑录按钮: Region2D<u32> = ltrb!(957, 135, 1221, 371);
+pub(crate) const ROI_见闻辑录按钮: Region2D<u32> = ltrb!(957, 135, 1221, 371);
 
 /// 中枢档案按钮 ROI (958, 369, 1220, 601)
-const ROI_中枢档案按钮: Region2D<u32> = ltrb!(958, 369, 1220, 601);
+pub(crate) const ROI_中枢档案按钮: Region2D<u32> = ltrb!(958, 369, 1220, 601);
 
 /// 颜色判断阈值：灰度 < 128 视为深色（选中状态）
 const DARK_THRESHOLD: u8 = 128;
@@ -221,9 +223,9 @@ impl Scene档案库子界面 {
         context: &RecognitionContext<'_>,
         category: &str,
     ) -> Result<档案库SubSceneId> {
-        let tab0_dark = context.is_roi_dark(ltwh!(180, 120, 60, 36), DARK_THRESHOLD);
-        let tab1_dark = context.is_roi_dark(ltwh!(180, 184, 60, 36), DARK_THRESHOLD);
-        let tab2_dark = context.is_roi_dark(ltwh!(180, 248, 60, 36), DARK_THRESHOLD);
+        let tab0_dark = context.is_roi_dark(TAB_ROIS[0], DARK_THRESHOLD);
+        let tab1_dark = context.is_roi_dark(TAB_ROIS[1], DARK_THRESHOLD);
+        let tab2_dark = context.is_roi_dark(TAB_ROIS[2], DARK_THRESHOLD);
 
         match category {
             "音像存档" => {

--- a/src-tauri/src/scene/scenes/overworld.rs
+++ b/src-tauri/src/scene/scenes/overworld.rs
@@ -7,10 +7,10 @@ use anyhow::Result;
 use super::super::model::{Scene, SceneAction, SceneId, SceneTransition};
 use super::TEMPLATE_MATCH_THRESHOLD;
 use crate::session::RecognitionContext;
-use crate::utils::region::Region2D;
+use crate::utils::region::{Region2D, ltrb};
 
 /// 协议终端按钮 ROI (1180, 0, 1280, 100)
-const ROI_协议终端按钮: Region2D<u32> = Region2D::from_ltrb(1180, 0, 1280, 100);
+const ROI_协议终端按钮: Region2D<u32> = ltrb!(1180, 0, 1280, 100);
 
 /// 大世界界面。
 pub struct Scene大世界;

--- a/src-tauri/src/scene/scenes/terminal.rs
+++ b/src-tauri/src/scene/scenes/terminal.rs
@@ -7,10 +7,10 @@ use anyhow::Result;
 use super::super::model::{Scene, SceneAction, SceneId, SceneTransition};
 use super::TEMPLATE_MATCH_THRESHOLD;
 use crate::session::RecognitionContext;
-use crate::utils::region::Region2D;
+use crate::utils::region::{Region2D, ltrb};
 
 /// 档案库按钮 ROI (971, 108, 1280, 700)
-const ROI_档案库按钮: Region2D<u32> = Region2D::from_ltrb(971, 108, 1280, 700);
+const ROI_档案库按钮: Region2D<u32> = ltrb!(971, 108, 1280, 700);
 
 /// 协议终端界面。
 pub struct Scene协议终端;

--- a/src-tauri/src/session/recognition_context.rs
+++ b/src-tauri/src/session/recognition_context.rs
@@ -45,8 +45,7 @@ impl<'a> RecognitionContext<'a> {
     }
 
     /// 判断矩形区域的平均灰度是否低于 `threshold`。
-    pub fn is_roi_dark_ltwh(&self, x: u32, y: u32, width: u32, height: u32, threshold: u8) -> bool {
-        let roi = Region2D::from_ltwh(x, y, width, height);
+    pub fn is_roi_dark(&self, roi: Region2D<u32>, threshold: u8) -> bool {
         let cropped = imageops::crop_imm(self.frame, roi.x0(), roi.y0(), roi.width(), roi.height());
         let gray = imageops::grayscale(&cropped.to_image());
         let pixel_count = (roi.width() * roi.height()) as u64;

--- a/src-tauri/src/task/archive_scan/constants.rs
+++ b/src-tauri/src/task/archive_scan/constants.rs
@@ -2,20 +2,19 @@
 //!
 //! 所有坐标均基于 1280×720 基准分辨率，识别时截图会先缩放到此分辨率。
 
-use crate::from_ltwh;
-use crate::utils::region::Region2D;
+use crate::utils::region::{Region2D, ltrb, ltwh};
 
 /// 模板匹配默认阈值
 pub const THRESHOLD: f32 = 0.75;
 
 /// 档案标题 OCR 识别区域（720p 基准 ltwh）
-pub const OCR_ROI: Region2D<u32> = from_ltwh!(350, 58, 578, 42);
+pub const OCR_ROI: Region2D<u32> = ltwh!(350, 58, 578, 42);
 
 /// "下一篇" 按钮搜索区域（720p 基准 ltrb）
-pub const NEXT_BUTTON_ROI: Region2D<u32> = Region2D::from_ltrb(762, 654, 925, 711);
+pub const NEXT_BUTTON_ROI: Region2D<u32> = ltrb!(762, 654, 925, 711);
 
 /// "档案详情右箭头" 搜索区域（720p 基准 ltrb）
-pub const ARROW_RIGHT_ROI: Region2D<u32> = Region2D::from_ltrb(1206, 313, 1276, 423);
+pub const ARROW_RIGHT_ROI: Region2D<u32> = ltrb!(1206, 313, 1276, 423);
 
 /// "档案详情关闭" 按钮搜索区域（720p 基准 ltrb）
-pub const CLOSE_BUTTON_ROI: Region2D<u32> = Region2D::from_ltrb(1180, 0, 1280, 100);
+pub const CLOSE_BUTTON_ROI: Region2D<u32> = ltrb!(1180, 0, 1280, 100);

--- a/src-tauri/src/task/archive_scan/task.rs
+++ b/src-tauri/src/task/archive_scan/task.rs
@@ -10,7 +10,7 @@ use crate::{
     scene::{SceneAction, SceneId, scene_manager::SceneManager, 档案库SubSceneId},
     session::Session,
     task::Task,
-    utils::region::Region2D,
+    utils::region::ltrb,
 };
 
 use super::correction::{CorrectionOverride, DEFAULT_CORRECTION_OVERRIDES};
@@ -112,14 +112,14 @@ impl ArchiveScanTask<'_> {
         // 截图并搜索入口按钮
         let screenshot = session.screencap_for_recognition()?;
         let roi = match step.first_sub_scene {
-            档案库SubSceneId::音像存档_多媒体 => Region2D::from_ltrb(692, 371, 959, 601),
+            档案库SubSceneId::音像存档_多媒体 => ltrb!(692, 371, 959, 601),
             档案库SubSceneId::见闻辑录_纸质记录 => {
-                Region2D::from_ltrb(957, 135, 1221, 371)
+                ltrb!(957, 135, 1221, 371)
             }
             档案库SubSceneId::中枢档案_中枢档案 => {
-                Region2D::from_ltrb(958, 369, 1220, 601)
+                ltrb!(958, 369, 1220, 601)
             }
-            _ => Region2D::from_ltrb(692, 371, 959, 601), // fallback
+            _ => ltrb!(692, 371, 959, 601), // fallback
         };
 
         let found = session.find_and_click_template(&screenshot, step.entry_template, roi, 0.75)?;

--- a/src-tauri/src/task/archive_scan/task.rs
+++ b/src-tauri/src/task/archive_scan/task.rs
@@ -7,10 +7,14 @@ use anyhow::Result;
 use tracing::info;
 
 use crate::{
-    scene::{SceneAction, SceneId, scene_manager::SceneManager, 档案库SubSceneId},
+    scene::{
+        SceneAction, SceneId,
+        archive::{ROI_中枢档案按钮, ROI_见闻辑录按钮, ROI_音像存档按钮},
+        scene_manager::SceneManager,
+        档案库SubSceneId,
+    },
     session::Session,
     task::Task,
-    utils::region::ltrb,
 };
 
 use super::correction::{CorrectionOverride, DEFAULT_CORRECTION_OVERRIDES};
@@ -112,14 +116,10 @@ impl ArchiveScanTask<'_> {
         // 截图并搜索入口按钮
         let screenshot = session.screencap_for_recognition()?;
         let roi = match step.first_sub_scene {
-            档案库SubSceneId::音像存档_多媒体 => ltrb!(692, 371, 959, 601),
-            档案库SubSceneId::见闻辑录_纸质记录 => {
-                ltrb!(957, 135, 1221, 371)
-            }
-            档案库SubSceneId::中枢档案_中枢档案 => {
-                ltrb!(958, 369, 1220, 601)
-            }
-            _ => ltrb!(692, 371, 959, 601), // fallback
+            档案库SubSceneId::音像存档_多媒体 => ROI_音像存档按钮,
+            档案库SubSceneId::见闻辑录_纸质记录 => ROI_见闻辑录按钮,
+            档案库SubSceneId::中枢档案_中枢档案 => ROI_中枢档案按钮,
+            _ => ROI_音像存档按钮, // fallback
         };
 
         let found = session.find_and_click_template(&screenshot, step.entry_template, roi, 0.75)?;

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -1,7 +1,7 @@
 //! 通用工具（基础设施，通用库）。
 //!
 //! - [`point`]：二维点 `Point2D`（含 az 泛型转换）；
-//! - [`region`]：矩形区域 `Region2D`（720p 基准 ROI 的核心类型，含 `from_ltwh!` 常量宏）；
+//! - [`region`]：矩形区域 `Region2D`（720p 基准 ROI 的核心类型）；
 //! - [`timeit`]：计时工具。
 
 pub mod point;

--- a/src-tauri/src/utils/region.rs
+++ b/src-tauri/src/utils/region.rs
@@ -4,9 +4,10 @@ use az::{Cast, CheckedCast, OverflowingCast, SaturatingCast, StrictCast, Wrappin
 
 use crate::utils::point::Point2D;
 
-/// 泛型二维矩形区域结构体。
+/// 以 left、top、right、bottom 四条边界定义的泛型二维矩形区域。
 ///
-/// 约定 `p0` 为区域左上角（left, top），`p1` 为区域右下角（right, bottom）。
+/// `(left, top)` 为左上角，可通过 [`p0`](Self::p0) 访问；`(right, bottom)` 为右下角，
+/// 可通过 [`p1`](Self::p1) 访问。
 /// 区域使用半开区间 `[left, right) × [top, bottom)`；构造时不检查边界顺序。
 /// 支持 ltrb（left/top/right/bottom）与 ltwh（left/top/width/height）两种构造方式。
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/src-tauri/src/utils/region.rs
+++ b/src-tauri/src/utils/region.rs
@@ -4,16 +4,17 @@ use az::{Cast, CheckedCast, OverflowingCast, SaturatingCast, StrictCast, Wrappin
 
 use crate::utils::point::Point2D;
 
-/// 泛型二维矩形区域结构体，由左上角 `p0` 和右下角 `p1` 两个点定义。
+/// 泛型二维矩形区域结构体。
 ///
 /// 约定 `p0` 为区域左上角（left, top），`p1` 为区域右下角（right, bottom）。
+/// 区域使用半开区间 `[left, right) × [top, bottom)`；构造时不检查边界顺序。
 /// 支持 ltrb（left/top/right/bottom）与 ltwh（left/top/width/height）两种构造方式。
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Region2D<T> {
-    /// 区域左上角坐标
-    p0: Point2D<T>,
-    /// 区域右下角坐标
-    p1: Point2D<T>,
+    left: T,
+    top: T,
+    right: T,
+    bottom: T,
 }
 
 impl<T> Region2D<T> {
@@ -21,7 +22,12 @@ impl<T> Region2D<T> {
     ///
     /// `p0` 应为左上角，`p1` 应为右下角。
     pub fn from_points(p0: Point2D<T>, p1: Point2D<T>) -> Self {
-        Self { p0, p1 }
+        Self {
+            left: p0.x,
+            top: p0.y,
+            right: p1.x,
+            bottom: p1.y,
+        }
     }
 
     /// 以 ltwh（left, top, width, height）格式构造 [`Region2D<T>`]。
@@ -32,11 +38,10 @@ impl<T> Region2D<T> {
         T: Copy + Add<Output = T>,
     {
         Self {
-            p0: Point2D { x, y },
-            p1: Point2D {
-                x: x + width,
-                y: y + height,
-            },
+            left: x,
+            top: y,
+            right: x + width,
+            bottom: y + height,
         }
     }
 
@@ -45,11 +50,10 @@ impl<T> Region2D<T> {
     /// 此方法为 `const fn`，可用于编译期常量声明。
     pub const fn from_ltrb(left: T, top: T, right: T, bottom: T) -> Self {
         Self {
-            p0: Point2D { x: left, y: top },
-            p1: Point2D {
-                x: right,
-                y: bottom,
-            },
+            left,
+            top,
+            right,
+            bottom,
         }
     }
 
@@ -58,7 +62,10 @@ impl<T> Region2D<T> {
     where
         T: Copy,
     {
-        self.p0
+        Point2D {
+            x: self.left,
+            y: self.top,
+        }
     }
 
     /// 返回区域右下角点 `p1`。
@@ -66,7 +73,10 @@ impl<T> Region2D<T> {
     where
         T: Copy,
     {
-        self.p1
+        Point2D {
+            x: self.right,
+            y: self.bottom,
+        }
     }
 
     /// 返回左上角 x 坐标（等同于 [`left`](Self::left)）。
@@ -74,7 +84,7 @@ impl<T> Region2D<T> {
     where
         T: Copy,
     {
-        self.p0.x
+        self.left
     }
 
     /// 返回左上角 y 坐标（等同于 [`top`](Self::top)）。
@@ -82,7 +92,7 @@ impl<T> Region2D<T> {
     where
         T: Copy,
     {
-        self.p0.y
+        self.top
     }
 
     /// 返回右下角 x 坐标（等同于 [`right`](Self::right)）。
@@ -90,7 +100,7 @@ impl<T> Region2D<T> {
     where
         T: Copy,
     {
-        self.p1.x
+        self.right
     }
 
     /// 返回右下角 y 坐标（等同于 [`bottom`](Self::bottom)）。
@@ -98,7 +108,7 @@ impl<T> Region2D<T> {
     where
         T: Copy,
     {
-        self.p1.y
+        self.bottom
     }
 
     /// 返回区域左边界 x 坐标（等同于 [`x0`](Self::x0)）。
@@ -106,7 +116,7 @@ impl<T> Region2D<T> {
     where
         T: Copy,
     {
-        self.p0.x
+        self.left
     }
 
     /// 返回区域上边界 y 坐标（等同于 [`y0`](Self::y0)）。
@@ -114,7 +124,7 @@ impl<T> Region2D<T> {
     where
         T: Copy,
     {
-        self.p0.y
+        self.top
     }
 
     /// 返回区域右边界 x 坐标（等同于 [`x1`](Self::x1)）。
@@ -122,7 +132,7 @@ impl<T> Region2D<T> {
     where
         T: Copy,
     {
-        self.p1.x
+        self.right
     }
 
     /// 返回区域下边界 y 坐标（等同于 [`y1`](Self::y1)）。
@@ -130,7 +140,7 @@ impl<T> Region2D<T> {
     where
         T: Copy,
     {
-        self.p1.y
+        self.bottom
     }
 
     /// 返回区域宽度 `right - left`。
@@ -138,7 +148,7 @@ impl<T> Region2D<T> {
     where
         T: Copy + Sub<Output = T>,
     {
-        self.p1.x - self.p0.x
+        self.right - self.left
     }
 
     /// 返回区域高度 `bottom - top`。
@@ -146,7 +156,7 @@ impl<T> Region2D<T> {
     where
         T: Copy + Sub<Output = T>,
     {
-        self.p1.y - self.p0.y
+        self.bottom - self.top
     }
 
     /// 返回区域中心点坐标 `(x_center, y_center)`。
@@ -156,8 +166,8 @@ impl<T> Region2D<T> {
         u8: Cast<T>,
     {
         Point2D {
-            x: (self.p0.x + self.p1.x) / 2.cast(),
-            y: (self.p0.y + self.p1.y) / 2.cast(),
+            x: (self.left + self.right) / 2.cast(),
+            y: (self.top + self.bottom) / 2.cast(),
         }
     }
 
@@ -176,10 +186,12 @@ where
 {
     /// 将 [`Region2D<T>`] 转换为 [`Region2D<U>`]，其中 `T` 可以转换为 `U`。
     fn cast(self) -> Region2D<U> {
-        Region2D {
-            p0: self.p0.cast(),
-            p1: self.p1.cast(),
-        }
+        Region2D::from_ltrb(
+            self.left.cast(),
+            self.top.cast(),
+            self.right.cast(),
+            self.bottom.cast(),
+        )
     }
 }
 
@@ -189,10 +201,12 @@ where
 {
     /// 尝试将 [`Region2D<T>`] 转换为 [`Region2D<U>`]，如果 `T` 无法转换为 `U`，则返回 `None`。
     fn checked_cast(self) -> Option<Region2D<U>> {
-        Some(Region2D {
-            p0: self.p0.checked_cast()?,
-            p1: self.p1.checked_cast()?,
-        })
+        Some(Region2D::from_ltrb(
+            self.left.checked_cast()?,
+            self.top.checked_cast()?,
+            self.right.checked_cast()?,
+            self.bottom.checked_cast()?,
+        ))
     }
 }
 
@@ -202,10 +216,12 @@ where
 {
     /// 将 [`Region2D<T>`] 严格转换为 [`Region2D<U>`]，如果 `T` 无法严格转换为 `U`，则会 panic。
     fn strict_cast(self) -> Region2D<U> {
-        Region2D {
-            p0: self.p0.strict_cast(),
-            p1: self.p1.strict_cast(),
-        }
+        Region2D::from_ltrb(
+            self.left.strict_cast(),
+            self.top.strict_cast(),
+            self.right.strict_cast(),
+            self.bottom.strict_cast(),
+        )
     }
 }
 
@@ -215,10 +231,12 @@ where
 {
     /// 将 [`Region2D<T>`] 饱和转换为 [`Region2D<U>`]，如果 `T` 超出 `U` 的范围，则会返回 `U` 的边界值。
     fn saturating_cast(self) -> Region2D<U> {
-        Region2D {
-            p0: self.p0.saturating_cast(),
-            p1: self.p1.saturating_cast(),
-        }
+        Region2D::from_ltrb(
+            self.left.saturating_cast(),
+            self.top.saturating_cast(),
+            self.right.saturating_cast(),
+            self.bottom.saturating_cast(),
+        )
     }
 }
 
@@ -228,10 +246,12 @@ where
 {
     /// 将 [`Region2D<T>`] 环绕转换为 [`Region2D<U>`]，如果 `T` 超出 `U` 的范围，则会环绕回 `U` 的范围内。
     fn wrapping_cast(self) -> Region2D<U> {
-        Region2D {
-            p0: self.p0.wrapping_cast(),
-            p1: self.p1.wrapping_cast(),
-        }
+        Region2D::from_ltrb(
+            self.left.wrapping_cast(),
+            self.top.wrapping_cast(),
+            self.right.wrapping_cast(),
+            self.bottom.wrapping_cast(),
+        )
     }
 }
 
@@ -241,9 +261,14 @@ where
 {
     /// 将 [`Region2D<T>`] 溢出转换为 [`Region2D<U>`]，如果 `T` 超出 `U` 的范围，则会返回溢出标志。
     fn overflowing_cast(self) -> (Region2D<U>, bool) {
-        let (p0, p0_overflow) = self.p0.overflowing_cast();
-        let (p1, p1_overflow) = self.p1.overflowing_cast();
-        (Region2D { p0, p1 }, p0_overflow || p1_overflow)
+        let (left, left_overflow) = self.left.overflowing_cast();
+        let (top, top_overflow) = self.top.overflowing_cast();
+        let (right, right_overflow) = self.right.overflowing_cast();
+        let (bottom, bottom_overflow) = self.bottom.overflowing_cast();
+        (
+            Region2D::from_ltrb(left, top, right, bottom),
+            left_overflow || top_overflow || right_overflow || bottom_overflow,
+        )
     }
 }
 

--- a/src-tauri/src/utils/region.rs
+++ b/src-tauri/src/utils/region.rs
@@ -149,24 +149,6 @@ impl<T> Region2D<T> {
         self.p1.y - self.p0.y
     }
 
-    /// 返回区域中心点 x 坐标 `(left + right) / 2`。
-    pub fn x_center(&self) -> T
-    where
-        T: Copy + Add<Output = T> + Div<Output = T>,
-        u8: Cast<T>,
-    {
-        (self.p0.x + self.p1.x) / 2.cast()
-    }
-
-    /// 返回区域中心点 y 坐标 `(top + bottom) / 2`。
-    pub fn y_center(&self) -> T
-    where
-        T: Copy + Add<Output = T> + Div<Output = T>,
-        u8: Cast<T>,
-    {
-        (self.p0.y + self.p1.y) / 2.cast()
-    }
-
     /// 返回区域中心点坐标 `(x_center, y_center)`。
     pub fn center(&self) -> Point2D<T>
     where
@@ -174,8 +156,8 @@ impl<T> Region2D<T> {
         u8: Cast<T>,
     {
         Point2D {
-            x: self.x_center(),
-            y: self.y_center(),
+            x: (self.p0.x + self.p1.x) / 2.cast(),
+            y: (self.p0.y + self.p1.y) / 2.cast(),
         }
     }
 
@@ -185,38 +167,6 @@ impl<T> Region2D<T> {
         T: Copy + Sub<Output = T> + Mul<Output = T>,
     {
         self.width() * self.height()
-    }
-
-    /// 分别对四条边应用不同的 padding（向外扩展）。
-    ///
-    /// 正值向外扩展，负值向内收缩。
-    /// 参数顺序为 `(padding_left, padding_top, padding_right, padding_bottom)`。
-    pub fn apply_padding_ltrb(
-        &self,
-        padding_left: T,
-        padding_top: T,
-        padding_right: T,
-        padding_bottom: T,
-    ) -> Self
-    where
-        T: Copy + Add<Output = T> + Sub<Output = T>,
-    {
-        Self::from_ltrb(
-            self.left() - padding_left,
-            self.top() - padding_top,
-            self.right() + padding_right,
-            self.bottom() + padding_bottom,
-        )
-    }
-
-    /// 四条边应用相同的 padding（向外扩展）。
-    ///
-    /// 正值向外扩展，负值向内收缩。
-    pub fn apply_padding(&self, padding: T) -> Self
-    where
-        T: Copy + Add<Output = T> + Sub<Output = T>,
-    {
-        self.apply_padding_ltrb(padding, padding, padding, padding)
     }
 }
 
@@ -297,19 +247,26 @@ where
     }
 }
 
-/// 以 ltwh 格式创建 `Region2D<u32>` 的 const 友好宏。
-///
-/// `from_ltwh` 因泛型 trait bound 无法标记为 `const fn`，
-/// 此宏展开为 `from_ltrb(x, y, x + w, y + h)`，所有参数在编译期求值。
-///
-/// # 示例
-/// ```
-/// use oea_lib::{from_ltwh, utils::region::Region2D};
-/// const ROI: Region2D<u32> = from_ltwh!(180, 120, 60, 36);
-/// ```
-#[macro_export]
-macro_rules! from_ltwh {
-    ($x:expr, $y:expr, $w:expr, $h:expr) => {
-        $crate::utils::region::Region2D::from_ltrb($x, $y, $x + $w, $y + $h)
-    };
+/// 以 ltwh 格式创建 `Region2D`，可用于常量声明。
+macro_rules! ltwh {
+    ($left:expr, $top:expr, $width:expr, $height:expr $(,)?) => {{
+        let left = $left;
+        let top = $top;
+        let width = $width;
+        let height = $height;
+        $crate::utils::region::Region2D::from_ltrb(left, top, left + width, top + height)
+    }};
 }
+
+/// 以 ltrb 格式创建 `Region2D`，可用于常量声明。
+macro_rules! ltrb {
+    ($left:expr, $top:expr, $right:expr, $bottom:expr $(,)?) => {{
+        let left = $left;
+        let top = $top;
+        let right = $right;
+        let bottom = $bottom;
+        $crate::utils::region::Region2D::from_ltrb(left, top, right, bottom)
+    }};
+}
+
+pub(crate) use {ltrb, ltwh};


### PR DESCRIPTION
> This message is generated by AI.

后端的矩形区域此前同时以 `Region2D`、四个标量参数和匿名四元组传递。相同的档案库坐标还分别维护在识别与点击路径中，坐标格式与所有权不清晰，后续调整容易产生漂移。

本 PR 将 `Region2D<T>` 确立为后端矩形区域的统一运行时表示。LTWH 与 LTRB 继续作为输入格式，通过 crate 内的 `ltwh!`、`ltrb!` 表达固定布局，通过构造函数处理运行时计算结果。

```diff
-is_roi_dark_ltwh(x, y, width, height, threshold)
+is_roi_dark(roi: Region2D<u32>, threshold)

-const ROI: (u32, u32, u32, u32) = (x, y, width, height);
+const ROI: Region2D<u32> = ltwh!(x, y, width, height);
```

档案库的三个入口区域改为由场景模块单点维护。侧边栏 tab 区域改为一组共享的 `Region2D` 常量，识别与点击读取同一组坐标。`ClickSubTab { roi_index }` 的索引查找和无效索引错误保持不变，点击坐标由 `Region2D::center()` 计算。

```diff
 archive recognition ─┐
-                      ├─ duplicated LTWH literals
 ClickSubTab lookup ───┘
+
 archive recognition ─┐
+                      ├─ TAB_ROIS: [Region2D<u32>; 3]
 ClickSubTab lookup ───┘
```

`Region2D<T>` 的内部存储改为 `left/top/right/bottom` 四条边，减少矩形实现对 `Point2D` 布局的耦合。现有的点构造与访问接口、两套边界访问器和数值转换实现均继续保留，因此调用方不依赖内部表示。

```diff
 struct Region2D<T> {
-    p0: Point2D<T>,
-    p1: Point2D<T>,
+    left: T,
+    top: T,
+    right: T,
+    bottom: T,
 }
```

同时删除了未使用的中心坐标辅助方法、padding 方法和 `GameResolution::scale_ltrb`。矩形继续采用不校验边界顺序的半开区间 `[left, right) × [top, bottom)` 约定。

## Sourcery 总结

标准化后端 ROI 处理，并集中管理归档坐标，以确保识别路径和交互路径保持一致。

增强功能：
- 统一后端矩形区域，围绕 `Region2D` 使用共享的 LTWH/LTRB 构造宏，并采用稳定的半开区间边界约定。
- 集中管理归档条目和子标签页区域，使识别、模板扫描和点击操作共享相同的坐标。
- 简化 `Region2D` 内部实现，同时保留其公开的构造、访问、中心点和数值转换 API。

维护事项：
- 移除未使用的矩形填充和中心坐标辅助工具，以及已废弃的分辨率矩形缩放支持。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

统一后端 ROI 表示方式，并集中管理归档坐标，以确保识别和交互路径保持一致。

增强功能：
- 将后端矩形区域标准化为 `Region2D`，采用共享的 LTWH/LTRB 构造方式和半开区间边界语义。
- 集中管理归档条目和子标签页区域，使识别、模板扫描和点击操作使用一致的坐标。
- 简化 `Region2D` 的存储方式，同时保留其公开的构造、访问、中心点和数值转换 API。

维护工作：
- 移除未使用的矩形内边距和中心坐标辅助函数，以及已废弃的分辨率矩形缩放工具。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify backend ROI representation and centralize archive coordinates to keep recognition and interaction paths consistent.

Enhancements:
- Standardize backend rectangular regions on `Region2D` with shared LTWH/LTRB construction and half-open boundary semantics.
- Centralize archive entry and sub-tab regions so recognition, template scanning, and clicking use consistent coordinates.
- Simplify `Region2D` storage while preserving its public construction, access, center, and numeric conversion APIs.

Chores:
- Remove unused rectangle padding and center-coordinate helpers and the obsolete resolution rectangle-scaling utility.

</details>

</details>