### PR TITLE
docs(backend:scene): 补充档案库标签区域说明

### DIFF
--- a/src-tauri/src/scene/model/scene_action.rs
+++ b/src-tauri/src/scene/model/scene_action.rs
@@ -8,6 +8,7 @@ use crate::{
     utils::region::{Region2D, ltwh},
 };
 
+/// 档案库侧边栏从上到下三个 tab 的颜色检测与点击区域（720p 基准 LTWH）。
 pub(crate) const TAB_ROIS: [Region2D<u32>; 3] = [
     ltwh!(180, 120, 60, 36),
     ltwh!(180, 184, 60, 36),


### PR DESCRIPTION
> This message is generated by AI.

[#55](https://github.com/Logical-Byte/open-endfield-assistant/pull/55) 将 `TAB_ROIS` 从 `ClickSubTab` 的局部实现提升为识别与点击共享的常量，原有注释没有随常量一起移动，读者需要从调用方推断这组三个固定区域的用途与排列顺序。

本 PR 在常量定义处补充档案库侧边栏语义、从上到下的顺序以及 720p LTWH 坐标约定，使坐标用途与其唯一维护位置保持在一起。

```diff
+/// 档案库侧边栏从上到下三个 tab 的颜色检测与点击区域（720p 基准 LTWH）。
 pub(crate) const TAB_ROIS: [Region2D<u32>; 3] = [
```

运行逻辑与坐标值均未改变。

## Sourcery 生成的摘要

文档：
- 记录归档侧边栏标签区域、其从上到下的排序，以及与共享常量一同说明的 720p LTWH 坐标约定。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Document the archive sidebar tab regions, their top-to-bottom ordering, and the 720p LTWH coordinate convention alongside the shared constant.

</details>