### PR TITLE
refactor(backend:path): 统一解析受限资源文件路径

### DIFF
--- a/src-tauri/src/app_paths.rs
+++ b/src-tauri/src/app_paths.rs
@@ -18,6 +18,8 @@ use std::{
 
 use anyhow::{Context, Result};
 
+use crate::utils::path::resolve_existing_relative_file;
+
 /// 在运行时确定应用根目录，按构建类型分发。
 ///
 /// - debug 构建：`CARGO_MANIFEST_DIR`（编译期指向 `src-tauri/`）的上一级即项目根；
@@ -85,6 +87,12 @@ impl AppPaths {
         self.root_dir.join("resources")
     }
 
+    /// 解析并验证共享资源目录内当前存在的文件。
+    pub fn resolve_resource_file(&self, relative_path: &str) -> Result<PathBuf> {
+        resolve_existing_relative_file(&self.resources_dir(), relative_path)
+            .with_context(|| format!("解析资源文件失败: {relative_path:?}"))
+    }
+
     /// OCR 模型目录（`<root_dir>/resources/ocr-models`）。
     pub fn models_dir(&self) -> PathBuf {
         self.root_dir.join("resources").join("ocr-models")
@@ -118,5 +126,29 @@ impl AppPaths {
     /// OEA 应用配置文件（`<root_dir>/config/oea_config.json`）。
     pub fn oea_config_file(&self) -> PathBuf {
         self.config_dir().join("oea_config.json")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::AppPaths;
+
+    #[test]
+    fn resolves_an_existing_resource_file() {
+        let root = tempfile::tempdir().unwrap();
+        let sounds_dir = root.path().join("resources").join("sounds");
+        fs::create_dir_all(&sounds_dir).unwrap();
+        let sound_file = sounds_dir.join("enable.wav");
+        fs::write(&sound_file, b"wav").unwrap();
+        let app_paths = AppPaths::with_root_dir(root.path());
+
+        assert_eq!(
+            app_paths
+                .resolve_resource_file("sounds/enable.wav")
+                .unwrap(),
+            sound_file.canonicalize().unwrap()
+        );
     }
 }

--- a/src-tauri/src/data/mod.rs
+++ b/src-tauri/src/data/mod.rs
@@ -21,6 +21,19 @@ pub(crate) mod schema;
 pub use archive_title_index::ArchiveTitleIndex;
 pub use schema::{ArchiveContract, PrtsData};
 
+/// 读取并解析一个 JSON 文件；失败时错误信息带完整文件路径。
+fn load_json<T: DeserializeOwned>(path: &Path) -> Result<T> {
+    let text = fs::read_to_string(path)
+        .with_context(|| format!("读取数据文件 {} 失败", path.display()))?;
+    serde_json::from_str(&text).with_context(|| format!("解析数据文件 {} 失败", path.display()))
+}
+
+/// 解析并加载 `resources/` 内的一个 JSON 文件。
+fn load_resource_json<T: DeserializeOwned>(app_paths: &AppPaths, relative_path: &str) -> Result<T> {
+    let path = app_paths.resolve_resource_file(relative_path)?;
+    load_json(&path)
+}
+
 /// 运行时加载的静态数据（不可变，跨线程只读共享）。
 pub struct AppData {
     /// prts.json 完整数据（供前端查询分类中文名 / 自动补全候选，并构建档案标题索引）
@@ -34,14 +47,12 @@ pub struct AppData {
 impl AppData {
     /// 从 `resources/data/` 加载全部静态数据文件（新增数据文件在此登记）。
     pub fn load(app_paths: &AppPaths) -> Result<Self> {
-        let data_dir = app_paths.resources_dir().join("data");
-
-        let prts = Self::load_json::<PrtsData>(&data_dir.join("prts.json"))?;
+        let prts = load_resource_json::<PrtsData>(app_paths, "data/prts.json")?;
         let archive_titles = ArchiveTitleIndex::from_prts(&prts);
         info!("已加载 prts.json（{} 个档案条目）", archive_titles.len());
 
         let archive_contract =
-            Self::load_json::<ArchiveContract>(&data_dir.join("archive_contract.json"))?;
+            load_resource_json::<ArchiveContract>(app_paths, "data/archive_contract.json")?;
         let row_count: usize = archive_contract.categories.values().map(Vec::len).sum();
         info!("已加载 archive_contract.json（{} 条获取契约）", row_count);
 
@@ -65,12 +76,5 @@ impl AppData {
     /// 档案标题索引。
     pub fn archive_titles(&self) -> &ArchiveTitleIndex {
         &self.archive_titles
-    }
-
-    /// 读取并解析一个 JSON 数据文件；失败时错误信息带完整文件路径。
-    fn load_json<T: DeserializeOwned>(path: &Path) -> Result<T> {
-        let text = fs::read_to_string(path)
-            .with_context(|| format!("读取数据文件 {} 失败", path.display()))?;
-        serde_json::from_str(&text).with_context(|| format!("解析数据文件 {} 失败", path.display()))
     }
 }

--- a/src-tauri/src/scan_runtime.rs
+++ b/src-tauri/src/scan_runtime.rs
@@ -81,6 +81,22 @@ enum ScanOutcome {
     Failed(String),
 }
 
+/// 扫描生命周期使用的提示音。
+#[derive(Debug, Clone, Copy)]
+enum ScanSound {
+    Enable,
+    Disable,
+}
+
+impl ScanSound {
+    const fn relative_path(self) -> &'static str {
+        match self {
+            Self::Enable => "sounds/enable.wav",
+            Self::Disable => "sounds/disable.wav",
+        }
+    }
+}
+
 /// 扫描档案库任务的生命周期状态。
 pub(crate) struct ScanRuntime {
     /// 停止请求标志：`true` 表示当前扫描应尽快停止。
@@ -176,7 +192,7 @@ impl ScanRuntime {
 
         // 启动检查通过、任务真正开始执行前播放 enable 提示音
         // （避免"启动后立即失败"时 enable/disable 两个音效同时播放）
-        self.play_scan_sound(context, true);
+        self.play_scan_sound(context, ScanSound::Enable);
 
         // 执行扫描档案库任务（阻塞，期间任务内部轮询停止标志）
         let task =
@@ -195,17 +211,17 @@ impl ScanRuntime {
         let scan_error = match outcome {
             ScanOutcome::Completed => {
                 info!("========== 扫描档案库任务执行完毕 ==========");
-                self.play_scan_sound(context, true);
+                self.play_scan_sound(context, ScanSound::Enable);
                 None
             }
             ScanOutcome::Stopped => {
                 info!("扫描档案库任务已被用户停止");
-                self.play_scan_sound(context, false);
+                self.play_scan_sound(context, ScanSound::Disable);
                 None
             }
             ScanOutcome::Failed(message) => {
                 error!("{message}");
-                self.play_scan_sound(context, false);
+                self.play_scan_sound(context, ScanSound::Disable);
                 Some(message)
             }
         };
@@ -215,14 +231,22 @@ impl ScanRuntime {
     }
 
     /// 播放扫描提示音（音量取配置；开始/自然完成播 enable，失败/被停止播 disable）。
-    fn play_scan_sound(&self, context: &ScanRunContext, enable: bool) {
+    fn play_scan_sound(&self, context: &ScanRunContext, sound: ScanSound) {
         let volume = context
             .oea_config
             .lock()
             .unwrap_or_else(|error| error.into_inner())
             .sound_volume;
-        let name = if enable { "enable.wav" } else { "disable.wav" };
-        let path = context.app_path.resources_dir().join("sounds").join(name);
+        let path = match context
+            .app_path
+            .resolve_resource_file(sound.relative_path())
+        {
+            Ok(path) => path,
+            Err(error) => {
+                warn!("无法解析扫描提示音资源: {error:#}");
+                return;
+            }
+        };
         windows_ops::sound::play_wav(&path, volume);
     }
 

--- a/src-tauri/src/template_matching/template_source.rs
+++ b/src-tauri/src/template_matching/template_source.rs
@@ -1,8 +1,10 @@
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result};
 use image::RgbImage;
+
+use crate::utils::path::resolve_existing_relative_file;
 
 /// 按逻辑名称提供模板图片，不向调用方暴露存储与缓存策略。
 pub(crate) trait TemplateSource {
@@ -29,8 +31,6 @@ impl LazyTemplateLoader {
 
 impl TemplateSource for LazyTemplateLoader {
     fn get(&mut self, template_name: &str) -> Result<&RgbImage> {
-        let path = resolve_template_path(&self.root, template_name)?;
-
         if self.cache.contains_key(template_name) {
             return Ok(self
                 .cache
@@ -38,19 +38,10 @@ impl TemplateSource for LazyTemplateLoader {
                 .expect("已缓存的模板应存在于缓存中"));
         }
 
-        let canonical_root = self
-            .root
-            .canonicalize()
-            .with_context(|| format!("规范化模板根目录失败: {}", self.root.display()))?;
-        let canonical_path = path
-            .canonicalize()
-            .with_context(|| format!("规范化模板路径失败: {}", path.display()))?;
-        if !canonical_path.starts_with(&canonical_root) {
-            bail!("模板路径超出模板根目录: {template_name:?}");
-        }
-
-        let image = image::open(&canonical_path)
-            .with_context(|| format!("加载模板图片失败: {}", canonical_path.display()))?
+        let path = resolve_existing_relative_file(&self.root, template_name)
+            .with_context(|| format!("解析模板文件失败: {template_name:?}"))?;
+        let image = image::open(&path)
+            .with_context(|| format!("加载模板图片失败: {}", path.display()))?
             .to_rgb8();
         self.cache.insert(template_name.to_owned(), image);
 
@@ -61,89 +52,26 @@ impl TemplateSource for LazyTemplateLoader {
     }
 }
 
-/// 将使用 `/` 分隔的模板名称解析到 `root` 内。
-///
-/// 逐段构造路径，使校验规则在开发环境与 Windows 运行环境中保持一致。
-fn resolve_template_path(root: &Path, template_name: &str) -> Result<PathBuf> {
-    if template_name.is_empty() {
-        bail!("模板名称不能为空");
-    }
-
-    let mut path = root.to_path_buf();
-    for segment in template_name.split('/') {
-        if segment.is_empty()
-            || segment == "."
-            || segment == ".."
-            || segment.contains('\\')
-            || segment.contains(':')
-        {
-            bail!("模板名称包含无效路径片段: {template_name:?}");
-        }
-        path.push(segment);
-    }
-
-    Ok(path)
-}
-
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
-
-    use super::resolve_template_path;
+    use std::fs;
 
     #[test]
-    fn resolves_valid_template_names_within_root() {
-        let root = Path::new("templates");
-
-        assert_eq!(
-            resolve_template_path(root, "档案库.png").unwrap(),
-            root.join("档案库.png")
-        );
-        assert_eq!(
-            resolve_template_path(root, "情报档案库/下一篇.png").unwrap(),
-            root.join("情报档案库").join("下一篇.png")
-        );
-    }
-
-    #[test]
-    fn rejects_template_names_that_can_escape_or_are_not_normalized() {
-        for template_name in [
-            "",
-            "/档案库.png",
-            "../档案库.png",
-            "情报档案库/../档案库.png",
-            "./档案库.png",
-            "情报档案库//档案库.png",
-            "情报档案库/",
-            r"C:\档案库.png",
-            r"\\server\share\档案库.png",
-            "档案库.png:stream",
-        ] {
-            assert!(
-                resolve_template_path(Path::new("templates"), template_name).is_err(),
-                "unexpectedly accepted {template_name:?}"
-            );
-        }
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn rejects_symlink_that_resolves_outside_template_root() {
-        use std::os::unix::fs::symlink;
-
+    fn returns_a_cached_template_after_its_file_is_removed() {
         use image::{Rgb, RgbImage};
 
         use super::{LazyTemplateLoader, TemplateSource};
 
         let templates = tempfile::tempdir().unwrap();
-        let outside = tempfile::tempdir().unwrap();
-        let outside_template = outside.path().join("outside.png");
+        let template = templates.path().join("cached.png");
         RgbImage::from_pixel(1, 1, Rgb([0, 0, 0]))
-            .save(&outside_template)
+            .save(&template)
             .unwrap();
-        symlink(&outside_template, templates.path().join("escaped.png")).unwrap();
 
         let mut loader = LazyTemplateLoader::new(templates.path());
-        assert!(loader.get("escaped.png").is_err());
+        loader.get("cached.png").unwrap();
+        fs::remove_file(template).unwrap();
+
+        assert_eq!(loader.get("cached.png").unwrap().width(), 1);
     }
 }

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -1,9 +1,11 @@
 //! 通用工具（基础设施，通用库）。
 //!
 //! - [`point`]：二维点 `Point2D`（含 az 泛型转换）；
+//! - [`path`]：受根目录约束的文件路径解析；
 //! - [`region`]：矩形区域 `Region2D`（720p 基准 ROI 的核心类型）；
 //! - [`timeit`]：计时工具。
 
+pub mod path;
 pub mod point;
 pub mod region;
 pub mod timeit;

--- a/src-tauri/src/utils/path.rs
+++ b/src-tauri/src/utils/path.rs
@@ -1,0 +1,118 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+
+/// 解析并验证当前存在于 `root` 内的相对文件路径。
+pub(crate) fn resolve_existing_relative_file(root: &Path, relative_path: &str) -> Result<PathBuf> {
+    if relative_path.is_empty() {
+        bail!("相对文件路径不能为空");
+    }
+
+    let mut path = root.to_path_buf();
+    for segment in relative_path.split('/') {
+        if segment.is_empty()
+            || segment == "."
+            || segment == ".."
+            || segment.contains('\\')
+            || segment.contains(':')
+        {
+            bail!("相对文件路径包含无效片段: {relative_path:?}");
+        }
+        path.push(segment);
+    }
+
+    let canonical_root = root
+        .canonicalize()
+        .with_context(|| format!("规范化根目录失败: {}", root.display()))?;
+    let canonical_path = path
+        .canonicalize()
+        .with_context(|| format!("规范化文件路径失败: {}", path.display()))?;
+
+    if !canonical_path.starts_with(&canonical_root) {
+        bail!("文件路径超出根目录: {relative_path:?}");
+    }
+    if !canonical_path.is_file() {
+        bail!("路径不是文件: {}", canonical_path.display());
+    }
+
+    Ok(canonical_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::resolve_existing_relative_file;
+
+    #[test]
+    fn resolves_an_existing_nested_file_within_root() {
+        let root = tempfile::tempdir().unwrap();
+        let nested_dir = root.path().join("nested");
+        fs::create_dir(&nested_dir).unwrap();
+        let file = nested_dir.join("resource.bin");
+        fs::write(&file, b"resource").unwrap();
+
+        assert_eq!(
+            resolve_existing_relative_file(root.path(), "nested/resource.bin").unwrap(),
+            file.canonicalize().unwrap()
+        );
+    }
+
+    #[test]
+    fn rejects_relative_paths_that_are_empty_or_not_normalized() {
+        let root = tempfile::tempdir().unwrap();
+        let nested_dir = root.path().join("nested");
+        fs::create_dir(&nested_dir).unwrap();
+        fs::write(root.path().join("resource.bin"), b"resource").unwrap();
+        fs::write(nested_dir.join("resource.bin"), b"resource").unwrap();
+
+        for relative_path in [
+            "",
+            "/resource.bin",
+            "../resource.bin",
+            "nested/../resource.bin",
+            "./resource.bin",
+            "nested//resource.bin",
+            "nested/",
+            r"nested\resource.bin",
+            "resource.bin:stream",
+        ] {
+            assert!(
+                resolve_existing_relative_file(root.path(), relative_path).is_err(),
+                "unexpectedly accepted {relative_path:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_missing_files_and_directories() {
+        let root = tempfile::tempdir().unwrap();
+        fs::create_dir(root.path().join("directory")).unwrap();
+        let missing_root = root.path().join("missing-root");
+
+        assert!(resolve_existing_relative_file(&missing_root, "resource.bin").is_err());
+        assert!(resolve_existing_relative_file(root.path(), "missing.bin").is_err());
+        assert!(resolve_existing_relative_file(root.path(), "directory").is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn allows_internal_symlinks_and_rejects_escaping_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let internal_file = root.path().join("internal.bin");
+        let outside_file = outside.path().join("outside.bin");
+        fs::write(&internal_file, b"internal").unwrap();
+        fs::write(&outside_file, b"outside").unwrap();
+        symlink(&internal_file, root.path().join("internal-link.bin")).unwrap();
+        symlink(&outside_file, root.path().join("escaping-link.bin")).unwrap();
+
+        assert_eq!(
+            resolve_existing_relative_file(root.path(), "internal-link.bin").unwrap(),
+            internal_file.canonicalize().unwrap()
+        );
+        assert!(resolve_existing_relative_file(root.path(), "escaping-link.bin").is_err());
+    }
+}


### PR DESCRIPTION
> This message is generated by AI.

#61 将 WAV 播放实现归入 `windows_ops` 后，扫描运行时仍自行拼接 `resources/sounds/*.wav`，模板加载器也独立维护一套相对路径校验与符号链接防逃逸逻辑。资源目录结构和文件安全约束因此分散在具体调用方中。

本变更在 `utils::path` 中提供通用的 `resolve_existing_relative_file`：逻辑路径统一使用 `/` 分段，拒绝未规范化或带平台歧义的片段，并在 canonicalize 后确认目标是根目录内当前存在的文件。`AppPaths::resolve_resource_file` 在该能力上固定 `resources/` 根目录，模板加载器和静态数据加载器也复用相同约束；缓存命中的模板仍直接从内存返回，不因磁盘文件后续变化而失效。

```diff
-template loader ── 自行校验 template root 与文件路径
-scan runtime    ── 自行拼接 resources/sounds/*.wav
+template loader ──┐
+AppData JSON    ──┼─ resolve_existing_relative_file(root, relative_path)
+AppPaths resources┘
+       ▲
+       └─ scan runtime 使用 ScanSound 的逻辑资源路径
```

扫描提示音选择由 `ScanSound::{Enable, Disable}` 表达，替代含义隐晦的 `bool`。enum 集中维护两个内置音效的相对路径，`ScanRuntime` 继续决定播放时机和读取音量，`windows_ops::sound` 继续负责平台播放。资源解析失败只记录 warning，不改变扫描任务的成功、停止或失败结果。

静态数据加载拆分为两个私有函数：`load_json` 只负责从已解析路径读取并反序列化 JSON，`load_resource_json` 负责将资源相对路径交给 `AppPaths` 校验。`AppData::load` 因此只登记具体数据资源并组装领域数据。

路径测试覆盖合法嵌套文件、缺失根目录与目标、目录目标、未规范化或跨平台歧义路径，以及 root 内外的符号链接。模板测试保留成功加载后的缓存语义。

## Sourcery 总结

统一后端受限资源文件路径解析与加载约束，消除各调用方分散的路径安全逻辑。

Bug 修复：
- 统一校验资源文件路径，拒绝未规范化、平台歧义、目录目标、缺失文件及通过符号链接逃逸根目录的访问。

改进：
- 集中提供受根目录约束的现有文件解析能力，并让模板、静态数据和扫描提示音加载复用统一规则。
- 使用明确的扫描提示音类型管理内置音效，同时保留模板缓存语义，并将资源解析失败降级为警告。

测试：
- 补充资源路径解析、符号链接安全、缺失目标及模板缓存行为的测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

统一后端受限资源文件的解析与加载约束。

Bug Fixes:
- 统一验证资源文件必须是根目录内当前存在的文件，拒绝路径穿越、平台歧义路径及越界符号链接。

Enhancements:
- 新增通用的受根目录约束的相对文件解析能力，并统一模板、静态 JSON 数据和扫描提示音的资源加载。
- 使用明确的扫描提示音类型表达启用与禁用状态，同时保留模板缓存语义及扫描任务结果行为。

Tests:
- 补充资源路径解析、缺失资源、目录目标、路径规范性及符号链接边界测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

统一后端受限资源文件的解析与加载约束。

Bug Fixes:
- 统一验证资源文件必须是根目录内当前存在的文件，拒绝路径穿越、平台歧义路径及越界符号链接。

Enhancements:
- 新增通用的受根目录约束的相对文件解析能力，并统一模板、静态 JSON 数据和扫描提示音的资源加载。
- 使用明确的扫描提示音类型表达启用与禁用状态，同时保留模板缓存语义及扫描任务结果行为。

Tests:
- 补充资源路径解析、缺失资源、目录目标、路径规范性及符号链接边界测试。

</details>

</details>