### PR TITLE
refactor(backend:platform): 收拢注册表与系统代理实现

### DIFF
--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -15,8 +15,7 @@ pub mod data_protection;
 pub mod dialog;
 pub mod hotkey;
 pub mod input;
-#[cfg(target_os = "windows")]
-pub mod registry;
+pub mod proxy;
 pub mod sound;
 pub mod webview;
 pub mod window;

--- a/src-tauri/src/platform/proxy.rs
+++ b/src-tauri/src/platform/proxy.rs
@@ -1,0 +1,17 @@
+//! 系统代理的平台接口。
+
+/// 解析当前系统配置的代理服务器。
+///
+/// 返回可直接用于 HTTP 客户端的 `http://host:port`；系统代理未启用或无法解析时返回
+/// `Ok(None)`。macOS 开发外壳不解析系统代理。
+pub fn resolve_system_proxy() -> Result<Option<String>, String> {
+    #[cfg(target_os = "windows")]
+    {
+        super::windows::proxy::resolve_system_proxy()
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        Ok(None)
+    }
+}

--- a/src-tauri/src/platform/windows/mod.rs
+++ b/src-tauri/src/platform/windows/mod.rs
@@ -7,6 +7,8 @@ pub(super) mod dpapi;
 mod geometry;
 pub(super) mod hotkey;
 pub(super) mod input;
+pub(super) mod proxy;
+pub(super) mod registry;
 pub(super) mod sound;
 pub(super) mod webview2;
 pub(super) mod window;

--- a/src-tauri/src/platform/windows/proxy.rs
+++ b/src-tauri/src/platform/windows/proxy.rs
@@ -1,0 +1,85 @@
+//! Windows 系统代理解析。
+
+use ::windows::Win32::System::Registry::HKEY_CURRENT_USER;
+use tracing::{info, warn};
+
+use super::registry::{read_registry_dword, read_registry_string};
+
+const INTERNET_SETTINGS: &str = r"Software\Microsoft\Windows\CurrentVersion\Internet Settings";
+
+/// 解析 Windows 系统代理（读取注册表 `Internet Settings`）。
+pub(in crate::platform) fn resolve_system_proxy() -> Result<Option<String>, String> {
+    // 读取失败或值缺失一律按未启用处理（无法解析系统代理时退化为直连）。
+    let enabled = read_registry_dword(HKEY_CURRENT_USER, INTERNET_SETTINGS, "ProxyEnable")
+        .unwrap_or_default()
+        .unwrap_or_default();
+    if enabled == 0 {
+        return Ok(None);
+    }
+
+    let server = read_registry_string(HKEY_CURRENT_USER, INTERNET_SETTINGS, "ProxyServer")
+        .unwrap_or_default()
+        .unwrap_or_default();
+    let Some(proxy) = normalize_proxy_server(&server) else {
+        warn!("系统代理 ProxyServer 格式无法解析: {server:?}");
+        return Ok(None);
+    };
+    info!("解析到系统代理: {proxy}");
+    Ok(Some(proxy))
+}
+
+/// 归一化注册表 `ProxyServer` 值：
+/// - `host:port` → `http://host:port`
+/// - `http=host:port;https=host2:port` → 优先 `https=`，否则 `http=`
+/// - 仅含 `socks=` 或无法解析时返回 `None`（reqwest 未启用 socks 特性）
+fn normalize_proxy_server(raw: &str) -> Option<String> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return None;
+    }
+
+    if raw.contains('=') {
+        let mut chosen: Option<&str> = None;
+        for part in raw.split(';') {
+            let part = part.trim();
+            if part.is_empty() {
+                continue;
+            }
+            let Some((scheme, addr)) = part.split_once('=') else {
+                continue;
+            };
+            let addr = addr.trim();
+            if addr.is_empty() {
+                continue;
+            }
+            if matches!(scheme.trim(), "http" | "https") {
+                chosen = Some(addr);
+                if scheme.trim() == "https" {
+                    break;
+                }
+            }
+        }
+        return chosen.map(|addr| format!("http://{addr}"));
+    }
+
+    Some(format!("http://{raw}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_proxy_server() {
+        assert_eq!(
+            normalize_proxy_server("127.0.0.1:7890"),
+            Some("http://127.0.0.1:7890".to_string())
+        );
+        assert_eq!(
+            normalize_proxy_server("http=127.0.0.1:7890;https=127.0.0.1:7891"),
+            Some("http://127.0.0.1:7891".to_string())
+        );
+        assert_eq!(normalize_proxy_server("socks=127.0.0.1:1080"), None);
+        assert_eq!(normalize_proxy_server(""), None);
+    }
+}

--- a/src-tauri/src/platform/windows/registry.rs
+++ b/src-tauri/src/platform/windows/registry.rs
@@ -1,4 +1,4 @@
-//! 注册表读取工具（仅 Windows）。
+//! Windows 注册表读取工具。
 //!
 //! 使用 `windows` crate 的 `RegGetValueW` 读取注册表值，供 WebView2 Runtime 检测、
 //! Windows 系统代理解析等模块复用（取代原 `winreg` crate 的用法）。
@@ -10,7 +10,7 @@ use ::windows::core::PCWSTR;
 /// 读取注册表中的字符串值（REG_SZ）。
 ///
 /// 如果键或值不存在，返回 `Ok(None)`。
-pub fn read_registry_string(
+pub(super) fn read_registry_string(
     hkey: HKEY,
     subkey: &str,
     value_name: &str,
@@ -74,7 +74,7 @@ pub fn read_registry_string(
 /// 读取注册表中的 DWORD 值（REG_DWORD）。
 ///
 /// 如果键或值不存在，返回 `Ok(None)`。
-pub fn read_registry_dword(
+pub(super) fn read_registry_dword(
     hkey: HKEY,
     subkey: &str,
     value_name: &str,

--- a/src-tauri/src/platform/windows/webview2/detection.rs
+++ b/src-tauri/src/platform/windows/webview2/detection.rs
@@ -2,7 +2,7 @@
 
 use ::windows::Win32::System::Registry::{HKEY, HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE};
 
-use crate::platform::registry::read_registry_string;
+use crate::platform::windows::registry::read_registry_string;
 
 /// 注册表检测位置（与 Tauri 安装器 `main.wxs` 的 `RegistrySearch` 一致）：
 /// - HKLM：per-machine 安装（64 位系统走 WOW6432Node 视图）

--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -19,8 +19,6 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tauri::Emitter;
 use tracing::info;
-#[cfg(target_os = "windows")]
-use tracing::warn;
 
 /// 下载进度事件（前端按 `session_id` 过滤旧任务的迟到事件）。
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -107,81 +105,6 @@ impl Drop for ProgressEmitterGuard {
     }
 }
 
-/// 解析 Windows 系统代理（读注册表 `Internet Settings`）。
-///
-/// 返回可直接交给 reqwest 的 `http://host:port`；未启用或格式无法解析时返回 `Ok(None)`。
-/// 复用 [`crate::platform::registry`] 的 `RegGetValueW` 实现（与 WebView2 检测共用）。
-#[cfg(target_os = "windows")]
-fn resolve_system_proxy_inner() -> Result<Option<String>, String> {
-    use windows::Win32::System::Registry::HKEY_CURRENT_USER;
-
-    use crate::platform::registry::{read_registry_dword, read_registry_string};
-
-    const INTERNET_SETTINGS: &str = r"Software\Microsoft\Windows\CurrentVersion\Internet Settings";
-
-    // 读取失败或值缺失一律按未启用处理（无法解析系统代理时退化为直连）
-    let enabled = read_registry_dword(HKEY_CURRENT_USER, INTERNET_SETTINGS, "ProxyEnable")
-        .unwrap_or_default()
-        .unwrap_or_default();
-    if enabled == 0 {
-        return Ok(None);
-    }
-
-    let server = read_registry_string(HKEY_CURRENT_USER, INTERNET_SETTINGS, "ProxyServer")
-        .unwrap_or_default()
-        .unwrap_or_default();
-    let Some(proxy) = normalize_proxy_server(&server) else {
-        warn!("系统代理 ProxyServer 格式无法解析: {server:?}");
-        return Ok(None);
-    };
-    info!("解析到系统代理: {proxy}");
-    Ok(Some(proxy))
-}
-
-/// 非 Windows 平台不解析系统代理（reqwest 默认直连）。
-#[cfg(not(target_os = "windows"))]
-fn resolve_system_proxy_inner() -> Result<Option<String>, String> {
-    Ok(None)
-}
-
-/// 归一化注册表 `ProxyServer` 值：
-/// - `host:port` → `http://host:port`
-/// - `http=host:port;https=host2:port` → 优先 `https=`，否则 `http=`
-/// - 仅含 `socks=` 或无法解析时返回 `None`（reqwest 未启用 socks 特性）
-#[cfg(any(target_os = "windows", test))]
-fn normalize_proxy_server(raw: &str) -> Option<String> {
-    let raw = raw.trim();
-    if raw.is_empty() {
-        return None;
-    }
-
-    if raw.contains('=') {
-        let mut chosen: Option<&str> = None;
-        for part in raw.split(';') {
-            let part = part.trim();
-            if part.is_empty() {
-                continue;
-            }
-            let Some((scheme, addr)) = part.split_once('=') else {
-                continue;
-            };
-            let addr = addr.trim();
-            if addr.is_empty() {
-                continue;
-            }
-            if matches!(scheme.trim(), "http" | "https") {
-                chosen = Some(addr);
-                if scheme.trim() == "https" {
-                    break;
-                }
-            }
-        }
-        return chosen.map(|addr| format!("http://{addr}"));
-    }
-
-    Some(format!("http://{raw}"))
-}
-
 /// 按代理模式构建 HTTP 客户端。
 ///
 /// - `none`：直连（显式 `no_proxy`）；
@@ -201,7 +124,7 @@ fn build_client(
 
     match proxy_mode.as_deref().unwrap_or("none") {
         "system" => {
-            if let Some(url) = resolve_system_proxy_inner()? {
+            if let Some(url) = crate::platform::proxy::resolve_system_proxy()? {
                 builder = builder.proxy(
                     reqwest::Proxy::all(url.as_str())
                         .map_err(|e| format!("系统代理配置失败: {e}"))?,
@@ -593,7 +516,7 @@ pub fn get_update_download_dir() -> Result<String, String> {
 /// 解析 Windows 系统代理（前端检查请求与 Rust 下载共用）。
 #[tauri::command]
 pub fn resolve_system_proxy() -> Result<Option<String>, String> {
-    resolve_system_proxy_inner()
+    crate::platform::proxy::resolve_system_proxy()
 }
 
 #[cfg(test)]
@@ -633,20 +556,6 @@ mod tests {
     fn test_percent_decode() {
         assert_eq!(percent_decode("a%20b%2Fc"), "a b/c");
         assert_eq!(percent_decode("plain"), "plain");
-    }
-
-    #[test]
-    fn test_normalize_proxy_server() {
-        assert_eq!(
-            normalize_proxy_server("127.0.0.1:7890"),
-            Some("http://127.0.0.1:7890".to_string())
-        );
-        assert_eq!(
-            normalize_proxy_server("http=127.0.0.1:7890;https=127.0.0.1:7891"),
-            Some("http://127.0.0.1:7891".to_string())
-        );
-        assert_eq!(normalize_proxy_server("socks=127.0.0.1:1080"), None);
-        assert_eq!(normalize_proxy_server(""), None);
     }
 
     #[test]


### PR DESCRIPTION
> This message is generated by AI.

`platform` 已经以公开 topic 模块和私有 Windows 实现区分平台接口，但注册表读取仍直接公开 `HKEY`、`WIN32_ERROR` 等 Win32 类型，更新模块也需要知道 `Internet Settings` 的注册表路径和值格式。这使 Windows 实现细节越过了 `platform` 的所有权范围。

重构前，更新业务和 WebView2 检测都直接依赖公开的注册表读取模块，其中更新业务还直接使用了 `HKEY_CURRENT_USER`：

```mermaid
flowchart TD
    subgraph business["业务模块"]
        update["update::build_client<br/>resolve_system_proxy command"]
        resolver["update::resolve_system_proxy_inner<br/>直接使用 HKEY_CURRENT_USER"]
        update --> resolver
    end

    registry["platform::registry<br/>公开注册表读取模块"]
    webview["platform::windows::webview2::detection"]
    win32["HKEY / WIN32_ERROR / RegGetValueW"]

    resolver --> registry
    webview --> registry
    registry --> win32
```

本次将注册表读取实现收进私有的 `platform::windows::registry`，并新增 `platform::proxy::resolve_system_proxy` 作为业务代码使用的稳定接口。Windows 的代理开关读取、代理地址读取和 `ProxyServer` 格式解析统一由 `platform::windows::proxy` 持有，macOS 开发外壳继续返回无系统代理。

重构后，业务代码只依赖系统代理这一平台接口。注册表路径、读取操作、错误类型和原生句柄都留在私有的 `platform::windows` 实现中：

```mermaid
flowchart TD
    subgraph business["业务模块"]
        update["update::build_client<br/>resolve_system_proxy command"]
    end

    proxy["platform::proxy::resolve_system_proxy<br/>稳定平台接口，无 Windows 类型"]

    subgraph windows["私有 platform::windows 实现"]
        windows_proxy["proxy<br/>系统代理检测与格式解析"]
        webview["webview2::detection"]
        registry["registry<br/>HKEY / WIN32_ERROR / RegGetValueW"]

        windows_proxy --> registry
        webview --> registry
    end

    update --> proxy
    proxy --> windows_proxy
```

```diff
 platform/
 ├── proxy.rs                    # 稳定的系统代理接口与平台分派
-├── registry.rs                 # 曾向业务代码暴露 Win32 类型
 └── windows/
+    ├── proxy.rs                # Internet Settings 与 ProxyServer 解析
+    ├── registry.rs             # HKEY、WIN32_ERROR、RegGetValueW
     └── webview2/detection.rs   # 在 Windows 私有区域复用注册表读取
```

现有 `resolve_system_proxy` Tauri command、前端调用协议、返回类型和容错行为保持不变。注册表值缺失、读取失败或代理格式无法解析时仍按未配置系统代理处理；已有注册表与代理解析测试随实现移动到 Windows 路径。

## Sourcery 摘要

将 Windows 注册表和系统代理详情封装在平台层中，同时提供跨平台代理接口，以支持功能更新。

新功能：
- 提供稳定的平台级系统代理解析接口，供业务模块使用。

增强功能：
- 将 Windows 注册表访问和系统代理解析移至私有的 Windows 平台实现中，同时保持现有的代理行为和命令契约。

测试：
- 保留 Windows 代理实现中的代理格式解析覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Encapsulate Windows registry and system proxy details within the platform layer while exposing a cross-platform proxy interface to update functionality.

New Features:
- Provide a stable platform-level system proxy resolution interface for business modules.

Enhancements:
- Move Windows registry access and system proxy parsing behind private Windows platform implementations while preserving existing proxy behavior and command contracts.

Tests:
- Keep proxy format parsing coverage with the Windows proxy implementation.

</details>