### PR TITLE
fix(backend:sound): 清理日志中的 Windows verbatim 路径前缀

### DIFF
--- a/src-tauri/src/platform/windows/sound.rs
+++ b/src-tauri/src/platform/windows/sound.rs
@@ -13,24 +13,34 @@ use tracing::{debug, warn};
 /// 全局默认输出流（首次播放时懒初始化，保活到进程退出）。
 static OUTPUT_STREAM: OnceLock<Option<OutputStream>> = OnceLock::new();
 
+/// 将 `canonicalize` 产生的 verbatim 路径转换为便于阅读的日志路径。
+fn path_for_log(path: &Path) -> String {
+    let path = path.display().to_string();
+    if let Some(path) = path.strip_prefix(r"\\?\UNC\") {
+        format!(r"\\{path}")
+    } else {
+        path.strip_prefix(r"\\?\").unwrap_or(&path).to_owned()
+    }
+}
+
 /// 播放 wav 音效文件（异步，立即返回；`volume` 取值 0.0–1.0）。
 pub(in crate::platform) fn play_wav(path: &Path, volume: f32) {
     let stream = OUTPUT_STREAM
         .get_or_init(|| OutputStreamBuilder::open_default_stream().ok())
         .as_ref();
     let Some(stream) = stream else {
-        warn!("打开默认音频输出设备失败，跳过音效: {}", path.display());
+        warn!("打开默认音频输出设备失败，跳过音效: {}", path_for_log(path));
         return;
     };
     let Ok(file) = File::open(path) else {
-        warn!("音效文件不存在: {}", path.display());
+        warn!("音效文件不存在: {}", path_for_log(path));
         return;
     };
     match Decoder::try_from(BufReader::new(file)) {
         Ok(source) => {
             stream.mixer().add(source.amplify(volume.clamp(0.0, 1.0)));
-            debug!("播放音效: {}", path.display());
+            debug!("播放音效: {}", path_for_log(path));
         }
-        Err(e) => warn!("解码音效失败 ({}): {e}", path.display()),
+        Err(e) => warn!("解码音效失败 ({}): {e}", path_for_log(path)),
     }
 }


### PR DESCRIPTION
> This message is generated by AI.

Windows 上的 `std::fs::canonicalize` 会返回带 `\\?\` 前缀的 verbatim 路径。扫描提示音在解析资源文件后直接记录该路径，因此日志会显示 `\\?\D:\...`。这个前缀适合 Windows 文件访问，但会给用户看到的日志增加无意义的实现细节。

本 PR 只调整 sound 模块的日志展示：盘符路径会从 `\\?\D:\...` 显示为 `D:\...`，verbatim UNC 路径会恢复为常规的 `\\server\share\...`。文件存在性检查、音频解码和播放仍然使用原始 canonical path，资源路径的安全校验行为保持不变。

```diff
 canonical resource path
 ├── File::open(path)                  # 保留 verbatim 路径用于文件访问
-└── log: \\?\D:\...                  # 暴露 Windows 内部路径前缀
+└── log: D:\...                       # 仅清理用户可见日志
```

Fixes #70

## Sourcery 摘要

错误修复：
- 清理 Windows 音效日志中的 verbatim 路径前缀，恢复盘符和 UNC 路径的常规显示格式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 清理 Windows 音效日志中的 verbatim 路径前缀，恢复盘符和 UNC 路径的常规显示格式。

</details>