### PR TITLE
refactor(update): 集中管理后端更新状态

### DIFF
--- a/src-tauri/src/app/mod.rs
+++ b/src-tauri/src/app/mod.rs
@@ -103,13 +103,13 @@ pub fn run() {
         .on_window_event(|window, event| {
             // 关闭窗口时：若启用最小化到托盘，则隐藏窗口而不是退出应用
             if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                let app_handle = window.app_handle();
                 // 安装更新期间拒绝关闭窗口（配合不可关闭的安装弹窗）
-                if update::is_installing() {
+                if app_handle.state::<update::UpdateManager>().is_installing() {
                     warn!("正在安装更新，拒绝关闭窗口");
                     api.prevent_close();
                     return;
                 }
-                let app_handle = window.app_handle();
                 let controller = app_handle.state::<Arc<Controller>>();
                 if controller
                     .oea_config()
@@ -143,6 +143,8 @@ pub fn run() {
 
 /// `setup` 主体：任何一步失败都会返回 `Err`，由 [`crash::report_fatal`] 统一兜底。
 fn setup_app(app: &mut tauri::App) -> Result<()> {
+    app.manage(update::UpdateManager::default());
+
     // 解析资源目录（`resources/models/logs`），不依赖运行时工作目录
     let app_paths = AppPaths::new()?;
 

--- a/src-tauri/src/controller.rs
+++ b/src-tauri/src/controller.rs
@@ -10,7 +10,7 @@
 use std::sync::{Arc, Mutex, mpsc};
 use std::thread;
 
-use tauri::{AppHandle, Emitter};
+use tauri::{AppHandle, Emitter, Manager};
 use tracing::{debug, error, info, warn};
 
 use crate::{
@@ -144,7 +144,11 @@ impl Controller {
 
     /// 退出程序：请求停止后退出 Tauri 应用。
     pub fn quit(&self) {
-        if crate::update::is_installing() {
+        if self
+            .handle
+            .state::<crate::update::UpdateManager>()
+            .is_installing()
+        {
             warn!("正在安装更新，拒绝退出");
             return;
         }

--- a/src-tauri/src/update/download.rs
+++ b/src-tauri/src/update/download.rs
@@ -3,7 +3,7 @@
 use std::{
     io::Write,
     path::{Path, PathBuf},
-    sync::atomic::{AtomicBool, AtomicU64, Ordering},
+    sync::Arc,
     time::Duration,
 };
 
@@ -13,7 +13,7 @@ use sha2::{Digest, Sha256};
 use tauri::Emitter;
 use tracing::info;
 
-use super::response::extract_filename_from_response;
+use super::{UpdateManager, response::extract_filename_from_response};
 
 /// 下载进度事件（前端按 `session_id` 过滤旧任务的迟到事件）。
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -42,13 +42,6 @@ pub struct DownloadResult {
     /// 检测到的文件名（未检测到时为 `None`）
     pub detected_filename: Option<String>,
 }
-
-/// 全局下载取消标志（每次下载开始前重置；前端模块级互斥保证同一时间只有一个下载）。
-static DOWNLOAD_CANCELLED: AtomicBool = AtomicBool::new(false);
-/// 当前下载会话编号（每次下载自增，旧任务的进度事件与取消请求据此失效）。
-static CURRENT_DOWNLOAD_SESSION: AtomicU64 = AtomicU64::new(0);
-/// 已下载字节数（仅作进度采样的共享计数，允许最终一致，用 `Relaxed` 序即可）。
-static DOWNLOADED_BYTES: AtomicU64 = AtomicU64::new(0);
 
 /// 临时文件守卫：下载异常退出时同步删除 `.downloading` 半成品，成功重命名后调用 `disarm`。
 struct TempFileGuard {
@@ -149,6 +142,7 @@ fn hex_encode(bytes: &[u8]) -> String {
 ///   客户端自动跟随 302 重定向。
 #[allow(clippy::too_many_arguments)] // 参数多但均为简单值，封装成结构体反而降低可读性
 pub async fn download_update(
+    manager: &UpdateManager,
     app: tauri::AppHandle,
     url: String,
     save_path: String,
@@ -159,9 +153,11 @@ pub async fn download_update(
     accept: Option<String>,
     user_agent: Option<String>,
 ) -> Result<DownloadResult, String> {
-    let session_id = CURRENT_DOWNLOAD_SESSION.fetch_add(1, Ordering::SeqCst) + 1;
-    DOWNLOAD_CANCELLED.store(false, Ordering::SeqCst);
-    DOWNLOADED_BYTES.store(0, Ordering::SeqCst);
+    let download = manager
+        .start_download()
+        .map_err(|error| error.to_string())?;
+    let session_id = download.id();
+    let session = download.session();
     info!("download_update: session={session_id} url={url} -> {save_path}");
 
     let save_path_obj = Path::new(&save_path);
@@ -232,6 +228,7 @@ pub async fn download_update(
     let app_for_emitter = app.clone();
     let (stop_tx, mut stop_rx) = tokio::sync::oneshot::channel::<()>();
     let progress_guard = ProgressEmitterGuard(Some(stop_tx));
+    let progress_session = Arc::clone(&session);
     tokio::spawn(async move {
         let mut last_downloaded = 0u64;
         let mut last_instant = tokio::time::Instant::now();
@@ -241,7 +238,7 @@ pub async fn download_update(
             tokio::select! {
                 _ = &mut stop_rx => break,
                 _ = tokio::time::sleep(Duration::from_millis(100)) => {
-                    let downloaded = DOWNLOADED_BYTES.load(Ordering::Relaxed);
+                    let downloaded = progress_session.downloaded_bytes();
                     let now = tokio::time::Instant::now();
                     let elapsed = now.duration_since(last_instant);
                     if elapsed.as_millis() == 0 {
@@ -283,9 +280,7 @@ pub async fn download_update(
     let mut download_error: Option<String> = None;
 
     while let Some(chunk) = stream.next().await {
-        if DOWNLOAD_CANCELLED.load(Ordering::SeqCst)
-            || CURRENT_DOWNLOAD_SESSION.load(Ordering::SeqCst) != session_id
-        {
+        if session.is_cancelled() {
             download_error = Some("下载已取消".to_string());
             break;
         }
@@ -303,14 +298,11 @@ pub async fn download_update(
             break;
         }
         downloaded += len;
-        DOWNLOADED_BYTES.store(downloaded, Ordering::Relaxed);
+        session.set_downloaded_bytes(downloaded);
     }
 
     // 收尾前再检查一次取消标志
-    if download_error.is_none()
-        && (DOWNLOAD_CANCELLED.load(Ordering::SeqCst)
-            || CURRENT_DOWNLOAD_SESSION.load(Ordering::SeqCst) != session_id)
-    {
+    if download_error.is_none() && session.is_cancelled() {
         download_error = Some("下载已取消".to_string());
     }
 
@@ -371,12 +363,6 @@ pub async fn download_update(
         actual_save_path: actual_save_path.to_string_lossy().into_owned(),
         detected_filename,
     })
-}
-
-/// 取消当前下载（置标志即可，临时文件由守卫清理）。
-pub fn cancel_download() {
-    DOWNLOAD_CANCELLED.store(true, Ordering::SeqCst);
-    info!("收到取消下载请求");
 }
 
 /// 返回更新包下载目录（`<root>/cache/downloads`），不存在时创建。

--- a/src-tauri/src/update/manager.rs
+++ b/src-tauri/src/update/manager.rs
@@ -1,0 +1,202 @@
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, AtomicU64, Ordering},
+};
+
+use anyhow::{Result, bail};
+
+/// 集中管理更新下载和安装的后端状态。
+pub struct UpdateManager {
+    inner: Mutex<UpdateState>,
+}
+
+struct UpdateState {
+    next_session_id: u64,
+    phase: UpdatePhase,
+}
+
+enum UpdatePhase {
+    Idle,
+    Downloading(Arc<DownloadSession>),
+    Installing,
+}
+
+pub(super) struct DownloadSession {
+    id: u64,
+    cancelled: AtomicBool,
+    downloaded_bytes: AtomicU64,
+}
+
+pub(super) struct DownloadLease<'a> {
+    manager: &'a UpdateManager,
+    session: Arc<DownloadSession>,
+}
+
+impl Default for UpdateManager {
+    fn default() -> Self {
+        Self {
+            inner: Mutex::new(UpdateState {
+                next_session_id: 0,
+                phase: UpdatePhase::Idle,
+            }),
+        }
+    }
+}
+
+impl UpdateManager {
+    pub(super) fn start_download(&self) -> Result<DownloadLease<'_>> {
+        let mut state = self.lock_state();
+        if matches!(state.phase, UpdatePhase::Installing) {
+            bail!("安装更新期间无法开始下载");
+        }
+
+        if let UpdatePhase::Downloading(previous) = &state.phase {
+            previous.cancel();
+        }
+
+        state.next_session_id += 1;
+        let session = Arc::new(DownloadSession {
+            id: state.next_session_id,
+            cancelled: AtomicBool::new(false),
+            downloaded_bytes: AtomicU64::new(0),
+        });
+        state.phase = UpdatePhase::Downloading(Arc::clone(&session));
+
+        Ok(DownloadLease {
+            manager: self,
+            session,
+        })
+    }
+
+    pub(super) fn cancel_download(&self) -> Result<()> {
+        let state = self.lock_state();
+        match &state.phase {
+            UpdatePhase::Downloading(session) => {
+                session.cancel();
+                Ok(())
+            }
+            UpdatePhase::Idle => bail!("当前没有正在进行的下载"),
+            UpdatePhase::Installing => bail!("安装更新期间无法取消下载"),
+        }
+    }
+
+    pub(super) fn begin_install(&self) -> Result<()> {
+        let mut state = self.lock_state();
+        match state.phase {
+            UpdatePhase::Idle => {
+                state.phase = UpdatePhase::Installing;
+                Ok(())
+            }
+            UpdatePhase::Downloading(_) => bail!("下载期间无法开始安装更新"),
+            UpdatePhase::Installing => bail!("更新安装已在进行"),
+        }
+    }
+
+    pub(super) fn finish_install(&self) -> Result<()> {
+        let mut state = self.lock_state();
+        if !matches!(state.phase, UpdatePhase::Installing) {
+            bail!("当前没有正在进行的更新安装");
+        }
+        state.phase = UpdatePhase::Idle;
+        Ok(())
+    }
+
+    pub(crate) fn is_installing(&self) -> bool {
+        let state = self.lock_state();
+        matches!(state.phase, UpdatePhase::Installing)
+    }
+
+    fn finish_download(&self, session_id: u64) {
+        let mut state = self.lock_state();
+        if matches!(&state.phase, UpdatePhase::Downloading(session) if session.id == session_id) {
+            state.phase = UpdatePhase::Idle;
+        }
+    }
+
+    fn lock_state(&self) -> std::sync::MutexGuard<'_, UpdateState> {
+        self.inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+impl DownloadLease<'_> {
+    pub(super) fn id(&self) -> u64 {
+        self.session.id
+    }
+
+    pub(super) fn session(&self) -> Arc<DownloadSession> {
+        Arc::clone(&self.session)
+    }
+}
+
+impl DownloadSession {
+    fn cancel(&self) {
+        self.cancelled.store(true, Ordering::Release);
+    }
+
+    pub(super) fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::Acquire)
+    }
+
+    pub(super) fn downloaded_bytes(&self) -> u64 {
+        self.downloaded_bytes.load(Ordering::Relaxed)
+    }
+
+    pub(super) fn set_downloaded_bytes(&self, bytes: u64) {
+        self.downloaded_bytes.store(bytes, Ordering::Relaxed);
+    }
+}
+
+impl Drop for DownloadLease<'_> {
+    fn drop(&mut self) {
+        self.manager.finish_download(self.session.id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::UpdateManager;
+
+    #[test]
+    fn replacing_download_isolates_sessions_and_ignores_stale_completion() {
+        let manager = UpdateManager::default();
+        let old = manager.start_download().unwrap();
+        let old_session = old.session();
+        old_session.set_downloaded_bytes(10);
+
+        let new = manager.start_download().unwrap();
+        let new_session = new.session();
+        new_session.set_downloaded_bytes(20);
+
+        assert!(old_session.is_cancelled());
+        assert!(!new_session.is_cancelled());
+        assert_eq!(old_session.downloaded_bytes(), 10);
+        assert_eq!(new_session.downloaded_bytes(), 20);
+
+        drop(old);
+        assert!(manager.begin_install().is_err());
+
+        drop(new);
+        manager.begin_install().unwrap();
+    }
+
+    #[test]
+    fn install_transitions_reject_wrong_phase_operations() {
+        let manager = UpdateManager::default();
+
+        assert!(manager.cancel_download().is_err());
+        manager.begin_install().unwrap();
+        assert!(manager.begin_install().is_err());
+        assert!(manager.start_download().is_err());
+        assert!(manager.cancel_download().is_err());
+        manager.finish_install().unwrap();
+
+        let download = manager.start_download().unwrap();
+        assert!(manager.begin_install().is_err());
+        drop(download);
+        manager.begin_install().unwrap();
+        manager.finish_install().unwrap();
+        assert!(manager.finish_install().is_err());
+    }
+}

--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -59,7 +59,10 @@ pub fn resolve_system_proxy() -> Result<Option<String>, String> {
     download::resolve_system_proxy()
 }
 
-/// 设置安装进行中标志（前端在安装开始/结束时调用）。
+/// 驱动更新安装状态迁移。
+///
+/// `installing = true` 仅允许从 `Idle` 进入 `Installing`；`false` 仅允许从
+/// `Installing` 返回 `Idle`。其他状态迁移会返回错误。
 #[tauri::command]
 pub fn set_update_installing(
     manager: tauri::State<'_, UpdateManager>,

--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -3,11 +3,11 @@
 pub mod install;
 
 mod download;
+mod manager;
 mod response;
 
 pub use download::{DownloadProgressEvent, DownloadResult};
-
-use std::sync::atomic::{AtomicBool, Ordering};
+pub use manager::UpdateManager;
 
 use tracing::info;
 
@@ -15,6 +15,7 @@ use tracing::info;
 #[allow(clippy::too_many_arguments)]
 #[tauri::command]
 pub async fn download_update(
+    manager: tauri::State<'_, UpdateManager>,
     app: tauri::AppHandle,
     url: String,
     save_path: String,
@@ -26,6 +27,7 @@ pub async fn download_update(
     user_agent: Option<String>,
 ) -> Result<DownloadResult, String> {
     download::download_update(
+        &manager,
         app,
         url,
         save_path,
@@ -41,8 +43,8 @@ pub async fn download_update(
 
 /// Cancel the current update download.
 #[tauri::command]
-pub fn cancel_download() {
-    download::cancel_download();
+pub fn cancel_download(manager: tauri::State<'_, UpdateManager>) -> Result<(), String> {
+    manager.cancel_download().map_err(|error| error.to_string())
 }
 
 /// Return the update package download directory.
@@ -57,17 +59,18 @@ pub fn resolve_system_proxy() -> Result<Option<String>, String> {
     download::resolve_system_proxy()
 }
 
-/// 安装进行中标志：安装期间拒绝退出（`quit` / 窗口关闭 / 托盘退出统一检查）。
-static UPDATE_INSTALLING: AtomicBool = AtomicBool::new(false);
-
-/// 当前是否正在安装更新。
-pub fn is_installing() -> bool {
-    UPDATE_INSTALLING.load(Ordering::SeqCst)
-}
-
 /// 设置安装进行中标志（前端在安装开始/结束时调用）。
 #[tauri::command]
-pub fn set_update_installing(installing: bool) {
-    UPDATE_INSTALLING.store(installing, Ordering::SeqCst);
+pub fn set_update_installing(
+    manager: tauri::State<'_, UpdateManager>,
+    installing: bool,
+) -> Result<(), String> {
+    let result = if installing {
+        manager.begin_install()
+    } else {
+        manager.finish_install()
+    };
+    result.map_err(|error| error.to_string())?;
     info!("设置更新安装状态: {installing}");
+    Ok(())
 }


### PR DESCRIPTION
> This message is generated by AI.

当前更新状态分散在多个全局原子变量中：下载取消、当前 session、下载进度和安装中标志分别维护。正常前端流程可以避免大部分冲突，但后端本身无法拒绝错误的 command 顺序或调用时机。

因此，本 PR 在下载模块拆分的基础上，引入由 Tauri 直接托管的 `UpdateManager`，将后端更新状态集中到私有状态机中：

```diff
 src-tauri/src/update/
 ├── download.rs  # 通过 session 读写下载状态
+├── manager.rs   # 拥有私有状态机与迁移规则
 └── mod.rs       # 将 Tauri command 接入 manager
```

```mermaid
stateDiagram-v2
    [*] --> Idle

    Idle --> Downloading: start_download()
    Downloading --> Downloading: start_download()<br/>cancel old session
    Downloading --> Downloading: cancel_download()<br/>mark current session cancelled
    Downloading --> Idle: current lease dropped

    Idle --> Installing: begin_install()
    Installing --> Idle: finish_install()
```

`UpdateManager` 内部使用私有 `std::sync::Mutex` 保存阶段和下载 session。Tauri 直接托管 manager，command 使用 `State<UpdateManager>`，没有额外的外层 `Arc`。

下载继续保留现有替换语义：新下载会取消旧 session，旧 session 迟到完成时不会清除新 session。取消标志和下载字节计数归各自的 `DownloadSession` 所有，RAII lease 在下载退出时收束当前 session。

下载和安装 command 的名称与参数保持不变。`set_update_installing(bool)` 仍为前端接口，`Controller::quit` 和窗口关闭处理通过 manager 查询安装状态。

无效状态迁移通过 `anyhow::Result` 返回前端可见的错误，因此后端会拒绝安装期间开始下载、下载期间开始安装、没有活动下载时取消，以及未进入安装状态时结束安装。替换下载和旧 session 迟到完成属于预期行为。

本 PR 不包含前端状态迁移、新的状态查询或事件协议、manifest 和 `changes.json` 处理、安装文件操作拆分，也不将第二次下载改为 `Busy`。

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

## Sourcery 总结

在经过验证的后端状态机之后集中管理更新生命周期，同时保留现有命令接口和下载替换语义。

错误修复：
- 拒绝无效的更新命令序列，包括在安装期间开始下载、在下载期间开始安装、在没有活动下载时取消，以及在非安装状态下完成安装。

增强功能：
- 将后端下载和安装状态集中到由 Tauri 管理的 UpdateManager 状态机中。
- 将取消操作和进度跟踪与单个下载会话关联，同时保留替换下载行为，并忽略过期会话的完成事件。
- 使用管理器的安装状态来保护退出和窗口关闭操作。

测试：
- 添加状态机测试，覆盖下载替换、会话隔离、过期完成事件和无效阶段转换。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过经过验证的后端状态机集中管理更新生命周期状态，同时保留现有的命令接口和下载替换语义。

错误修复：
- 拒绝无效的更新命令序列，包括在安装期间开始下载、在下载期间开始安装、没有活动下载时取消，以及在非安装阶段完成安装。

增强功能：
- 在由 Tauri 管理的 UpdateManager 状态机中集中管理后端下载和安装生命周期。
- 将取消操作和进度跟踪关联到各个下载会话，同时保留下载替换行为并忽略过时会话的完成事件。
- 使用管理器的安装状态，防止应用在更新期间退出或关闭窗口。

测试：
- 增加对下载替换、会话隔离、过时完成事件和无效阶段转换的状态机测试覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在经过验证的后端状态机后集中管理更新生命周期状态，同时保留现有的命令接口和下载替换语义。

错误修复：
- 拒绝无效的更新命令序列，包括在安装期间开始下载、在下载期间开始安装、没有活动下载时取消，以及在非安装状态下完成安装。

增强功能：
- 在由 Tauri 管理的 UpdateManager 状态机中集中管理后端下载和安装生命周期。
- 将取消操作和进度跟踪与单个下载会话关联，同时保留替换下载行为并忽略过时会话的完成信号。
- 使用管理器的安装状态，防止更新期间应用退出和窗口关闭。

测试：
- 增加针对下载替换、会话隔离、过时完成信号处理以及无效阶段转换的状态机测试覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在经过验证的后端状态机中集中管理更新生命周期状态，同时保留现有的命令接口和下载替换语义。

Bug 修复：
- 拒绝无效的更新命令序列，包括在安装期间开始下载、在下载期间开始安装、没有活动下载时取消，以及在非安装阶段完成安装。

增强功能：
- 在由 Tauri 管理的 UpdateManager 状态机中集中管理后端下载和安装生命周期。
- 将取消操作和进度跟踪与单个下载会话关联，同时保留替换下载行为，并忽略过时会话的完成事件。
- 使用集中式安装状态，防止更新期间应用退出和窗口关闭。

测试：
- 增加状态机测试，覆盖下载替换、会话隔离、过时完成事件处理以及无效阶段转换。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

在经过验证的后端状态机后集中管理更新生命周期状态，同时保留现有的命令接口和下载替换语义。

Bug 修复：
- 拒绝无效的更新命令序列，包括安装期间开始下载、下载期间开始安装、没有活动下载时取消，以及在安装阶段之外完成安装。

增强功能：
- 在由 Tauri 管理的 UpdateManager 状态机中集中管理后端下载和安装生命周期。
- 将取消操作和进度跟踪与单个下载会话关联，同时保留下载替换行为，并忽略过时会话的完成事件。
- 使用管理器的安装状态，在更新期间阻止应用退出和窗口关闭。

测试：
- 增加状态机测试覆盖下载替换、会话隔离、过时完成事件处理和无效阶段转换。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize update lifecycle state management behind a validated backend state machine while preserving the existing command interface and download replacement semantics.

Bug Fixes:
- Reject invalid update command sequences, including starting downloads during installation, starting installation during downloads, cancelling without an active download, and finishing installation outside the installing phase.

Enhancements:
- Centralize backend download and installation lifecycle management in a Tauri-managed UpdateManager state machine.
- Associate cancellation and progress tracking with individual download sessions while preserving replacement-download behavior and ignoring stale session completion.
- Use the manager's installation state to prevent application exit and window closure during updates.

Tests:
- Add state-machine coverage for download replacement, session isolation, stale completion handling, and invalid phase transitions.

</details>

</details>

</details>

</details>

</details>