### PR TITLE
feat(update): 支持开发者手动安装更新包

### DIFF
--- a/src-tauri/src/app/mod.rs
+++ b/src-tauri/src/app/mod.rs
@@ -89,6 +89,7 @@ pub fn run() {
             update::install::install_update,
             update::install::consume_startup_update_result,
             update::install::pending_package_exists,
+            update::install::extra::developer_choose_update_package,
         ])
         .on_window_event(|window, event| {
             // 关闭窗口时：若启用最小化到托盘，则隐藏窗口而不是退出应用

--- a/src-tauri/src/platform/update.rs
+++ b/src-tauri/src/platform/update.rs
@@ -11,10 +11,14 @@ use std::{
 };
 
 #[cfg(target_os = "macos")]
-use std::process::{Child, Command};
+use std::process::Child;
+#[cfg(target_os = "macos")]
+use std::process::Command;
 
 #[cfg(target_os = "windows")]
 use super::windows;
+
+pub(crate) mod extra;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum UpdatePromptMode {

--- a/src-tauri/src/platform/update/extra.rs
+++ b/src-tauri/src/platform/update/extra.rs
@@ -1,0 +1,57 @@
+//! 开发者选项使用的原生更新包选择器。
+
+use std::{
+    io,
+    path::{Path, PathBuf},
+};
+
+#[cfg(target_os = "macos")]
+use std::process::Command;
+
+/// 让开发者选择一个 ZIP 更新包，并在原生窗口中确认将退出应用执行安装。
+pub fn choose_update_package(default_directory: &Path) -> io::Result<Option<PathBuf>> {
+    #[cfg(target_os = "macos")]
+    {
+        choose_update_package_macos(default_directory)
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        crate::platform::windows::update::choose_update_package(default_directory)
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        let _ = default_directory;
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "update package picker is unsupported on this platform",
+        ))
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn choose_update_package_macos(default_directory: &Path) -> io::Result<Option<PathBuf>> {
+    let default_directory = super::apple_script_string(&default_directory.to_string_lossy());
+    let script = format!(
+        "set selectedFile to choose file with prompt \"选择用于更新测试的 ZIP\" default location POSIX file \"{default_directory}/\" of type {{\"public.zip-archive\"}}\n\
+         set selectedPath to POSIX path of selectedFile\n\
+         display dialog \"将安装以下本地更新包并退出 OEA：\\n\\n\" & selectedPath buttons {{\"取消\", \"安装并退出\"}} default button \"安装并退出\" cancel button \"取消\" with title \"OEA 开发者选项\"\n\
+         return selectedPath"
+    );
+    let output = Command::new("osascript").args(["-e", &script]).output()?;
+    if !output.status.success() {
+        return Ok(None);
+    }
+    output_path(&output.stdout).map(Some)
+}
+
+#[cfg(target_os = "macos")]
+fn output_path(stdout: &[u8]) -> io::Result<PathBuf> {
+    let path = String::from_utf8_lossy(stdout).trim().to_owned();
+    if path.is_empty() {
+        Err(io::Error::other("更新包选择器没有返回文件路径"))
+    } else {
+        Ok(PathBuf::from(path))
+    }
+}

--- a/src-tauri/src/platform/windows/update.rs
+++ b/src-tauri/src/platform/windows/update.rs
@@ -1,6 +1,12 @@
 //! Windows 更新文件原语。
 
-use std::{fs::File, io, os::windows::ffi::OsStrExt, os::windows::io::AsRawHandle, path::Path};
+use std::{
+    fs::File,
+    io,
+    os::windows::{ffi::OsStrExt, io::AsRawHandle, process::CommandExt},
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 // Cargo 的 Windows 测试 harness 没有 Tauri exe 携带的 Common Controls v6 manifest。
 // 测试本来就使用静默提示，因此不要把 `TaskDialogIndirect` 静态链接进测试 exe，
@@ -41,6 +47,44 @@ use ::windows::Win32::{
 
 #[cfg(not(test))]
 use crate::platform::dialog::{self, DialogIcon};
+
+/// 让开发者选择一个 ZIP 更新包，并确认将退出应用执行安装。
+pub(in crate::platform) fn choose_update_package(
+    default_directory: &Path,
+) -> io::Result<Option<PathBuf>> {
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    let default_directory = default_directory.to_string_lossy().replace('\'', "''");
+    let script = format!(
+        r#"Add-Type -AssemblyName System.Windows.Forms
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()
+$picker = New-Object System.Windows.Forms.OpenFileDialog
+$picker.Title = '选择用于更新测试的 ZIP'
+$picker.InitialDirectory = '{default_directory}'
+$picker.Filter = 'ZIP 更新包 (*.zip)|*.zip'
+if ($picker.ShowDialog() -ne [System.Windows.Forms.DialogResult]::OK) {{ exit 2 }}
+$answer = [System.Windows.Forms.MessageBox]::Show("将安装以下本地更新包并退出 OEA：`n`n$($picker.FileName)", 'OEA 开发者选项', [System.Windows.Forms.MessageBoxButtons]::YesNo, [System.Windows.Forms.MessageBoxIcon]::Warning)
+if ($answer -ne [System.Windows.Forms.DialogResult]::Yes) {{ exit 2 }}
+[Console]::Out.Write($picker.FileName)"#
+    );
+    let output = Command::new("powershell.exe")
+        .args(["-NoProfile", "-NonInteractive", "-Sta", "-Command", &script])
+        .creation_flags(CREATE_NO_WINDOW)
+        .output()?;
+    if output.status.code() == Some(2) {
+        return Ok(None);
+    }
+    if !output.status.success() {
+        return Err(io::Error::other(
+            String::from_utf8_lossy(&output.stderr).trim().to_owned(),
+        ));
+    }
+    let path = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    if path.is_empty() {
+        Err(io::Error::other("更新包选择器没有返回文件路径"))
+    } else {
+        Ok(Some(PathBuf::from(path)))
+    }
+}
 
 /// 获取文件上的 Windows 排他锁。
 pub(in crate::platform) fn lock_file(file: &File, nonblocking: bool) -> io::Result<bool> {

--- a/src-tauri/src/update/install/extra.rs
+++ b/src-tauri/src/update/install/extra.rs
@@ -1,0 +1,128 @@
+//! 开发者选项的本地更新包入口。
+
+use std::{
+    fs::{self, File, OpenOptions},
+    io,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use crate::app_paths::AppPaths;
+
+/// 选择本地 ZIP 并复制到受控下载目录，供开发者走完整的生产安装入口。
+#[tauri::command]
+pub fn developer_choose_update_package() -> Result<Option<String>, String> {
+    if cfg!(debug_assertions) {
+        return Err("开发构建禁止执行真实自更新，请使用 release 构建验证".to_string());
+    }
+
+    tracing::info!("[developer update] Rust picker command reached");
+    let paths = AppPaths::new().map_err(|error| format!("无法定位应用目录: {error}"))?;
+    let downloads = paths.cache_dir().join("downloads");
+    fs::create_dir_all(&downloads).map_err(|error| format!("创建更新下载目录失败: {error}"))?;
+    let Some(selected) = crate::platform::update::extra::choose_update_package(&downloads)
+        .map_err(|error| format!("选择更新包失败: {error}"))?
+    else {
+        tracing::info!("[developer update] native picker or confirmation cancelled");
+        return Ok(None);
+    };
+    let staged = stage_developer_package(&paths, &selected)?;
+    let staged = staged
+        .to_str()
+        .ok_or_else(|| "已复制更新包路径不是有效 UTF-8".to_string())?
+        .to_owned();
+    tracing::info!("[developer update] native confirmation accepted: {staged}");
+    Ok(Some(staged))
+}
+
+/// 导入用户明确选择的外部包到 `cache/downloads`；目录内的包直接复用。
+fn stage_developer_package(paths: &AppPaths, selected: &Path) -> Result<PathBuf, String> {
+    if !selected
+        .extension()
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("zip"))
+    {
+        return Err("请选择 .zip 更新包".to_string());
+    }
+
+    let downloads = paths.cache_dir().join("downloads");
+    fs::create_dir_all(&downloads).map_err(|error| format!("创建更新下载目录失败: {error}"))?;
+    let selected = selected
+        .canonicalize()
+        .map_err(|error| format!("解析所选更新包路径失败: {error}"))?;
+    let canonical_downloads = downloads
+        .canonicalize()
+        .map_err(|error| format!("解析更新下载目录失败: {error}"))?;
+    if selected.starts_with(&canonical_downloads) {
+        Ok(selected)
+    } else {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|error| format!("生成更新包暂存名称失败: {error}"))?
+            .as_nanos();
+        let staged = downloads.join(format!(
+            "developer-update-{}-{timestamp}.zip",
+            std::process::id()
+        ));
+        copy_to_new_file(&selected, &staged)?;
+        staged
+            .canonicalize()
+            .map_err(|error| format!("解析已复制更新包路径失败: {error}"))
+    }
+}
+
+/// 以 `create_new` 创建暂存文件，任何命名碰撞都不得覆盖另一个安装正在读取的包。
+fn copy_to_new_file(source: &Path, target: &Path) -> Result<(), String> {
+    let mut source = File::open(source).map_err(|error| format!("打开所选更新包失败: {error}"))?;
+    let mut target_file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(target)
+        .map_err(|error| format!("创建更新包暂存文件失败: {error}"))?;
+    if let Err(error) = io::copy(&mut source, &mut target_file) {
+        let _ = fs::remove_file(target);
+        return Err(format!("复制所选更新包到下载目录失败: {error}"));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn developer_update_command_rejects_debug_build() {
+        let error = developer_choose_update_package().unwrap_err();
+
+        assert_eq!(
+            error,
+            "开发构建禁止执行真实自更新，请使用 release 构建验证".to_string()
+        );
+    }
+
+    #[test]
+    fn developer_package_is_staged_in_controlled_download_directory() {
+        let root = tempfile::Builder::new()
+            .prefix("oea-update-developer-package-")
+            .tempdir()
+            .unwrap();
+        let external = tempfile::Builder::new()
+            .prefix("oea-update-external-package-")
+            .tempdir()
+            .unwrap();
+        let paths = AppPaths::with_root_dir(root.path());
+        let selected = external.path().join("selected.zip");
+        fs::write(&selected, "first package").unwrap();
+
+        let first_staged = stage_developer_package(&paths, &selected).unwrap();
+        fs::write(&selected, "second package").unwrap();
+        let second_staged = stage_developer_package(&paths, &selected).unwrap();
+
+        let downloads = paths.cache_dir().join("downloads").canonicalize().unwrap();
+        assert!(first_staged.starts_with(&downloads));
+        assert!(second_staged.starts_with(downloads));
+        assert_ne!(first_staged, second_staged);
+        assert_eq!(fs::read_to_string(first_staged).unwrap(), "first package");
+        assert_eq!(fs::read_to_string(second_staged).unwrap(), "second package");
+    }
+}

--- a/src-tauri/src/update/install/mod.rs
+++ b/src-tauri/src/update/install/mod.rs
@@ -16,6 +16,7 @@ use tauri::Emitter;
 use crate::app_paths::AppPaths;
 
 mod candidate;
+pub(crate) mod extra;
 mod helper;
 mod startup;
 mod workspace;

--- a/src/components/settings/DeveloperSettings.vue
+++ b/src/components/settings/DeveloperSettings.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import {
+  developerInstallBusy,
+  developerInstallTrace,
+  developerInstallUnavailable,
+  developerInstallUpdatePackage,
+} from '@/utils/app/developerUpdate';
+</script>
+
+<template>
+  <SettingsCard id="developer" class="scroll-mt-8" icon="i-lucide-code-2" title="开发者选项">
+    <div>
+      <UAlert
+        color="warning"
+        icon="i-lucide-triangle-alert"
+        title="如果你不知道自己在做什么，请不要使用下面的选项"
+        variant="subtle"
+      />
+    </div>
+    <SettingsItem
+      description="从给定的 .zip 更新包运行一次原地更新流程。支持增量包和全量包。"
+      icon="i-lucide-flask-conical"
+      title="安装更新包"
+    >
+      <div class="flex w-96 flex-col items-end gap-2">
+        <UButton
+          color="warning"
+          :disabled="developerInstallUnavailable"
+          icon="i-lucide-package-open"
+          label="选择 .zip 文件安装包（开发者）"
+          :loading="developerInstallBusy"
+          @click="developerInstallUpdatePackage"
+        />
+        <pre
+          class="max-h-52 w-full overflow-auto rounded-md bg-muted p-2 text-xs whitespace-pre-wrap text-toned"
+          >{{
+            developerInstallTrace.length > 0 ? developerInstallTrace.join('\n') : '相关日志'
+          }}</pre>
+      </div>
+    </SettingsItem>
+  </SettingsCard>
+</template>

--- a/src/pages/settings.vue
+++ b/src/pages/settings.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import DeveloperSettings from '@/components/settings/DeveloperSettings.vue';
 import { oeaVersion } from '@/main';
 import { UpdateProxyMode } from '@/types/oeaConfig';
 import { UpdateCheckStatus } from '@/types/update';
@@ -79,6 +80,7 @@ const sections = [
   { id: 'interface', icon: 'i-lucide-layout-panel-left', title: '界面设置' },
   { id: 'sound', icon: 'i-lucide-headphones', title: '声音设置' },
   { id: 'update', icon: 'i-lucide-download', title: '更新设置' },
+  { id: 'developer', icon: 'i-lucide-code-2', title: '开发者选项' },
 ];
 
 /** 当前高亮的设置分类 id。 */
@@ -308,6 +310,8 @@ onBeforeUnmount(() => {
             />
           </div>
         </SettingsCard>
+
+        <DeveloperSettings />
       </UPageBody>
     </UPage>
   </UContainer>

--- a/src/utils/app/developerUpdate.ts
+++ b/src/utils/app/developerUpdate.ts
@@ -1,0 +1,121 @@
+import { oeaVersion } from '@/main';
+import { UpdateSource } from '@/types/oeaConfig';
+import {
+  PreparedUpdate,
+  UpdateDownloadStatus,
+  UpdateInstallStageEvent,
+  UpdateInstallStatus,
+  UpdatePackageType,
+} from '@/types/update';
+import {
+  downloadSavePath,
+  downloadStatus,
+  installError,
+  installStatus,
+  preparedUpdate,
+  startInstall,
+} from '@/utils/app/update';
+import { logInfo } from '@/utils/tauri';
+import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
+import { computed, ref } from 'vue';
+
+/** 开发者选项手动安装流程的可见诊断日志。 */
+export const developerInstallTrace = ref<string[]>([]);
+/** 是否正在等待本地包选择或执行手动安装。 */
+export const developerInstallBusy = ref<boolean>(false);
+
+/** 普通更新状态占用安装入口时，不允许开始开发者流程。 */
+function hasUpdateActivity(): boolean {
+  return (
+    downloadStatus.value === UpdateDownloadStatus.Downloading ||
+    downloadStatus.value === UpdateDownloadStatus.Cancelling ||
+    downloadStatus.value === UpdateDownloadStatus.Completed ||
+    installStatus.value === UpdateInstallStatus.Installing
+  );
+}
+
+/** 开发者安装入口是否暂时不可用。 */
+export const developerInstallUnavailable = computed<boolean>(
+  () => developerInstallBusy.value || hasUpdateActivity(),
+);
+
+function appendTrace(message: string): void {
+  const line = `${new Date().toLocaleTimeString()} ${message}`;
+  developerInstallTrace.value.push(line);
+  console.info(`[developer update] ${message}`);
+  void logInfo(`[developer update] ${message}`).catch((error) => {
+    developerInstallTrace.value.push(
+      `${new Date().toLocaleTimeString()} Rust 日志转发失败: ${String(error)}`,
+    );
+  });
+}
+
+/** 更新流程正在使用共享状态时，拒绝覆盖其更新包。 */
+function refuseActiveUpdate(): boolean {
+  if (!hasUpdateActivity()) {
+    return false;
+  }
+  appendTrace('another update operation owns the package state; refusing developer install');
+  return true;
+}
+
+/** 从本地选择 ZIP，并从“下载完成”状态进入生产安装路径。 */
+export async function developerInstallUpdatePackage(): Promise<void> {
+  if (developerInstallBusy.value) {
+    return;
+  }
+  developerInstallTrace.value = [];
+  appendTrace('developer button clicked');
+  if (refuseActiveUpdate()) {
+    return;
+  }
+  developerInstallBusy.value = true;
+  appendTrace('invoking native Rust picker and confirmation');
+
+  let unlisten: (() => void) | null = null;
+  try {
+    const packagePath = await invoke<string | null>('developer_choose_update_package');
+    appendTrace(
+      packagePath === null
+        ? 'native picker or confirmation cancelled'
+        : `native confirmation accepted: ${packagePath}`,
+    );
+    if (packagePath === null) {
+      return;
+    }
+    const localUpdate: PreparedUpdate = {
+      url: '',
+      source: UpdateSource.Github,
+      // Rust 会根据 ZIP 内容识别全量包或增量包；这里仅满足共享前端状态的类型。
+      updateType: UpdatePackageType.Full,
+      versionName: oeaVersion,
+      releaseNote: '',
+    };
+    unlisten = await listen<UpdateInstallStageEvent>('update-install-stage', (event) => {
+      appendTrace(`Rust stage event: ${event.payload.stage}`);
+    });
+
+    // Picker 和事件订阅期间可能已有普通更新开始安装。此后到 `startInstall`
+    // 设置内部互斥标记之前不再让出事件循环，避免覆盖正在安装的包状态。
+    if (refuseActiveUpdate()) {
+      return;
+    }
+    preparedUpdate.value = localUpdate;
+    downloadSavePath.value = packagePath;
+    downloadStatus.value = UpdateDownloadStatus.Completed;
+    appendTrace('frontend package state prepared; entering production installer');
+    appendTrace(`invoking Rust install_update: ${packagePath}`);
+    const result = await startInstall();
+    if (result === 'failed') {
+      appendTrace(`developer flow failed: ${installError.value ?? 'Rust installer failed'}`);
+    } else if (result === 'skipped') {
+      appendTrace('developer install did not start because an install condition blocked it');
+    }
+  } catch (error) {
+    appendTrace(`developer flow failed: ${String(error)}`);
+  } finally {
+    unlisten?.();
+    developerInstallBusy.value = false;
+  }
+}

--- a/src/utils/app/update.ts
+++ b/src/utils/app/update.ts
@@ -300,7 +300,7 @@ export async function checkUpdate(): Promise<void> {
 export async function startDownload(
   checkUpdateData: MirrorchyanResourcesLatestResponseData,
 ): Promise<void> {
-  if (isDownloading) {
+  if (isDownloading || isInstalling) {
     return;
   }
   // 互斥锁必须在准备阶段之前占用：`prepareDownload` 含 GitHub API 请求（较慢），
@@ -517,10 +517,15 @@ export async function tryAutoInstall(): Promise<void> {
   await startInstall();
 }
 
+/** 安装启动结果：命令已接受、流程被条件阻止，或安装失败。 */
+export type InstallStartResult = 'started' | 'skipped' | 'failed';
+
 /** 开始安装（自动触发与手动「立即安装」共用；扫描任务运行中拒绝）。 */
-export async function startInstall(): Promise<void> {
-  if (isInstalling) {
-    return;
+export async function startInstall(): Promise<InstallStartResult> {
+  // 下载命令返回、状态已经进入 Completed 后，startDownload 的 finally 可能还没有
+  // 释放前端标记；此时 Rust 已结束下载，可以直接进入安装。其他下载阶段必须拒绝。
+  if (isInstalling || (isDownloading && downloadStatus.value !== UpdateDownloadStatus.Completed)) {
+    return 'skipped';
   }
   if (appStatus.value.running) {
     useToast().add({
@@ -529,7 +534,7 @@ export async function startInstall(): Promise<void> {
       icon: 'i-lucide-info',
       color: 'info',
     });
-    return;
+    return 'skipped';
   }
 
   const zipPath = downloadSavePath.value;
@@ -537,7 +542,7 @@ export async function startInstall(): Promise<void> {
   if (!zipPath || !prepared) {
     clearDownloadedUpdateState();
     handleInstallFailure(new Error('缺少下载包信息，请重新下载'));
-    return;
+    return 'failed';
   }
 
   isInstalling = true;
@@ -556,11 +561,13 @@ export async function startInstall(): Promise<void> {
     // Rust 会构造 candidate、发布 transaction 并启动 helper。helper 接管后当前进程
     // 退出，所以这里没有成功后的 relaunch，也没有可供前端继续编排的细粒度 command。
     await invoke('install_update', { packagePath: zipPath });
+    return 'started';
   } catch (error) {
     // Rust 在安装准备或 helper 启动失败时删除 zip；保留错误提示，但把下载态清空，
     // 使下一次重试从下载阶段开始，不会误用已经消费过的 zip。
     clearDownloadedUpdateState();
     handleInstallFailure(error);
+    return 'failed';
   } finally {
     unlisten?.();
     isInstalling = false;


### PR DESCRIPTION
> This message is generated by AI.

PR #76 建立了可恢复的事务安装流程，但开发者验证新生成的全量包或增量包时，仍需要手动把 ZIP 放入 `cache/downloads`，再自行构造前端下载完成状态。这个 PR 把本地包导入变成设置页中的开发者选项，让测试包能够经过与正常更新相同的 candidate、transaction、helper 和启动恢复链路。

## 从设置页到事务安装器

手动安装跨越两次 Tauri IPC 调用。第一次调用负责让用户选择并确认更新包，再把外部文件导入应用控制的下载目录；第二次调用进入 #76 提供的正式安装接口。安装阶段事件通过 IPC 反向送回前端，同时写入普通安装弹窗和开发者诊断日志。

```diff
 开发者验收本地更新包
-  手动复制 ZIP -> 手动构造前端状态 -> 调用安装器
+  设置页选择 ZIP -> Tauri IPC 导入 -> install_update
```

```text
DeveloperSettings.vue
  @click developerInstallUpdatePackage()
    检查普通下载、待安装包与安装互斥
    invoke("developer_choose_update_package")             # Vue -> Tauri IPC
      update::install::extra::developer_choose_update_package
        debug 构建立即拒绝
        platform::update::extra::choose_update_package
          Windows -> platform::windows::update
          macOS   -> AppleScript adapter
        stage_developer_package
          external ZIP -> cache/downloads/developer-update-<pid>-<time>.zip
    listen("update-install-stage")                        # Tauri IPC -> Vue
    准备共享前端安装状态
    startInstall()
      invoke("install_update")                            # Vue -> Tauri IPC
        detect package kind
        build candidate
        publish transaction
        spawn helper
        exit v1
```

`developer_choose_update_package` 在 `src-tauri/src/app/mod.rs` 中随其他 Tauri command 注册。跨 IPC 的返回值只有暂存后的应用内路径；`install_update` 继续只接受 `cache/downloads` 中的文件，因此开发者入口不会扩大事务安装器自身的路径边界。

## OS 相关实现

跨平台接口位于 `src-tauri/src/platform/update/extra.rs`，平台私有细节留在相应适配层：

| 平台 | 脚本与控件 | 行为 |
| --- | --- | --- |
| Windows | Rust 以 `powershell.exe -NoProfile -NonInteractive -Sta` 运行 PowerShell；脚本加载 `System.Windows.Forms`，使用 `OpenFileDialog` 选择 ZIP，并用 `MessageBox` 显示破坏性操作确认。`CommandExt` 与 `CREATE_NO_WINDOW` 留在 `platform::windows::update`。 | 用户取消返回空结果；确认后返回所选路径。 |
| macOS 开发外壳 | Rust 调用 `osascript`；AppleScript 使用 `choose file` 选择 ZIP，再用 `display dialog` 确认“安装并退出”。 | 用于本地开发验收，返回语义与 Windows 一致。 |

当前 Windows 选择器假设开发者环境能够提供 `powershell.exe`，并允许加载 `System.Windows.Forms`。这个约定依赖外部运行环境，较为脆弱；后续可以改为由 Rust 直接调用 Windows 原生对话框 API，消除对 PowerShell 脚本的依赖。

用户确认后，Rust 校验 `.zip` 扩展名并 canonicalize 路径，再通过 `create_new` 复制到 `cache/downloads`。暂存名包含进程号和纳秒时间戳；即使出现跨窗口或异常重复调用，后一次导入也无法覆盖安装器正在读取的文件。全量包与增量包由 `PackageKind::detect` 根据 ZIP 内容识别，前端的共享状态不参与类型判定。

## 前端状态与并发

设置页始终编译并展示独立的 `DeveloperSettings` 组件。`developerUpdate.ts` 保存“正在选择或安装”的前端互斥，并观察普通下载与安装状态：

```text
开发者按钮可用
  没有另一项开发者选择
  普通下载未占用共享状态
  没有等待安装的普通更新包
  install_update 未运行
```

原生选择器和 IPC listener 都会让出事件循环，因此前端在写入 `preparedUpdate`、`downloadSavePath` 之前再次检查共享状态。通过检查后，到 `startInstall` 设置安装互斥之间不再执行异步操作。普通下载入口也会在安装进行时拒绝启动，避免两条路径相互覆盖状态。

安装失败时，普通安装弹窗继续展示统一错误；开发者面板同时记录 Rust 返回的失败原因和每个 `update-install-stage` 事件。手动安装不伪造目标版本 metadata，重启后的成功反馈使用 #76 基于 Rust `completed` 事务结果提供的简化提示。

Debug 构建中的 `developer_choose_update_package` 在打开任何 OS 选择器之前立即返回错误，确保开发态不会触碰仓库对应的应用根目录。Release 构建使用同一套前端与后端代码进入完整选择和安装流程。

## Sourcery 总结

支持开发者通过标准的候选包、事务、辅助程序和启动恢复流程验证本地更新包。

新功能：
- 添加开发者设置工作流，支持通过常规更新事务管道选择并安装本地完整更新 ZIP 包或增量更新 ZIP 包。

错误修复：
- 更新安装过程中，阻止常规下载启动。
- 防止暂存的开发者软件包覆盖其他安装所使用的软件包。

增强功能：
- 为 Windows 和 macOS 添加跨平台原生软件包选择与确认支持。
- 添加开发者安装诊断功能，以及用于协调更新活动的前端共享状态。

测试：
- 添加对拒绝调试版本以及安全暂存多个开发者软件包的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable developers to validate local update packages through the standard candidate, transaction, helper, and startup recovery flow.

New Features:
- Add a developer settings workflow for selecting and installing local full or incremental update ZIP packages through the normal update transaction pipeline.

Bug Fixes:
- Prevent regular downloads from starting while an update installation is in progress.
- Prevent staged developer packages from overwriting packages used by another installation.

Enhancements:
- Add cross-platform native package selection and confirmation support for Windows and macOS.
- Add developer installation diagnostics and shared frontend state coordination for update activity.

Tests:
- Add coverage for debug-build rejection and safe staging of multiple developer packages.

</details>