### PR TITLE
fix(frontend): 修复长页面侧栏滚动遮挡

### DIFF
--- a/src/pages/help.vue
+++ b/src/pages/help.vue
@@ -83,7 +83,7 @@ onBeforeUnmount(() => {
       <template #left>
         <UPageAside
           :ui="{
-            root: 'lg:sticky lg:top-0 lg:max-h-[calc(100lvh-var(--ui-header-height)-var(--ui-title-height))] lg:overflow-y-auto',
+            root: 'lg:sticky lg:top-0 lg:max-h-[calc(100lvh-var(--ui-header-height)-var(--ui-title-height))] lg:self-start lg:overflow-y-auto',
           }"
         >
           <nav class="flex flex-col gap-1">

--- a/src/pages/settings.vue
+++ b/src/pages/settings.vue
@@ -131,7 +131,7 @@ onBeforeUnmount(() => {
       <template #left>
         <UPageAside
           :ui="{
-            root: 'lg:sticky lg:top-0 lg:max-h-[calc(100lvh-var(--ui-header-height)-var(--ui-title-height))] lg:overflow-y-auto',
+            root: 'lg:sticky lg:top-0 lg:max-h-[calc(100lvh-var(--ui-header-height)-var(--ui-title-height))] lg:self-start lg:overflow-y-auto',
           }"
         >
           <nav class="flex flex-col gap-1">


### PR DESCRIPTION
> This message is generated by AI.

设置页和帮助页的内容较长，滚动到底部会让左侧分类目录被推入顶栏下方，顶部项目因此部分或完全不可见。页脚进入视口后，这个问题稳定出现。

`UPageAside` 位于 `UPage` 的 Grid 行中，默认拉伸至接近整个可用视口高度。sticky 元素同时受父级底边约束，因此到达页面末尾时，父级会把整块侧栏向上推。

这次调整让两个页面的侧栏都从 Grid 起始位置按目录自身高度布局。目录继续使用原有的 sticky 定位、滚动锚点和高亮逻辑，页面滚动到底后也会完整停留在顶栏下方。

```diff
 UPage 的 Grid 行
 ├─ UPageAside
-│  └─ 默认 stretch，侧栏接近整屏高，父级底边会把它向上推
+│  └─ self-start，侧栏按目录内容高度吸附
 └─ UPageBody
```

## 修复前

在 1600×900 视口滚动到底后，设置页最上方的“界面设置”已经完全进入顶栏后方，“声音设置”也被向上推。

![设置页侧栏在修复前被顶栏遮挡](https://github.com/user-attachments/assets/2bf4ce2d-b648-470b-9cb3-83ce24fa1b2d)

帮助页的顶部目录项同样被顶栏遮挡：

![帮助页侧栏在修复前被顶栏遮挡](https://github.com/user-attachments/assets/fbd1249c-e626-4d67-9434-39611ef63e02)

## 修复后

相同视口和滚动位置下，三个分类项目均完整可见，侧栏外观和交互保持不变。

![设置页侧栏在修复后完整可见](https://github.com/user-attachments/assets/eec71259-cdb8-4222-bb0a-9e92b31ae9ae)

帮助页的七个分类项目也会完整停留在顶栏下方：

![帮助页侧栏在修复后完整可见](https://github.com/user-attachments/assets/34a9c673-60b7-40a2-a695-6479153611b6)

## Sourcery 摘要

错误修复：
- 防止帮助页面和设置页面的侧边栏在滚动到页面底部时被推到页眉下方。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent the help and settings page sidebars from being pushed beneath the header when scrolling to the bottom of the page.

</details>